### PR TITLE
fix: add skip-invalid-helm-release-paths to flux-local diff job

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -85,6 +85,7 @@ jobs:
             --limit-bytes 10000
             --all-namespaces
             --sources "flux-system"
+            --skip-invalid-helm-release-paths
             --output-file diff.patch
 
       - name: Generate Diff


### PR DESCRIPTION
## Summary
- Adds `--skip-invalid-helm-release-paths` flag to the flux-local diff job
- This flag was already present in the test job but missing from the diff job

## Problem
The flux-local diff job was failing when processing HelmReleases that source charts from GitRepositories (like `local-path-provisioner`). These charts can't be templated locally because the chart path (e.g., `./deploy/chart/local-path-provisioner`) only exists in the external git repository, not in this workspace.

## Test plan
- [ ] Verify flux-local workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)