### PR TITLE
fix: upgrade flux-local to v8.1.0

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Run flux-local test
-        uses: docker://ghcr.io/allenporter/flux-local:v8.0.0
+        uses: docker://ghcr.io/allenporter/flux-local:v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -74,7 +74,7 @@ jobs:
           path: default
 
       - name: Run flux-local diff
-        uses: docker://ghcr.io/allenporter/flux-local:v8.0.0
+        uses: docker://ghcr.io/allenporter/flux-local:v8.1.0
         with:
           args: >-
             diff ${{ matrix.resources }}


### PR DESCRIPTION
## Summary
- Upgrades flux-local from v8.0.0 to v8.1.0

## Problem
v8.0.0 doesn't support `--skip-invalid-helm-release-paths` in the diff command, causing failures when diffing HelmReleases that source charts from GitRepositories (like `local-path-provisioner`).

## Test plan
- [ ] Verify flux-local workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)