### PR TITLE
patch/bump sync todoist to habitica

### DIFF
--- a/kubernetes/apps/default/sync-todoist-to-habitica/cronjob/helmrelease.yaml
+++ b/kubernetes/apps/default/sync-todoist-to-habitica/cronjob/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           app:
             image:
               repository: casmith/sync-todoist-to-habitica
-              tag: 2026.02.11.4bd146da
+              tag: 2026.03.25-343c793
             env:
               TODOIST_UNMATCHED_DAILY_TASK: Todoist Daily
               CONFIG_DIR: /data


### PR DESCRIPTION
- **kube-system: remove Spegel (use external registry mirrors instead)**
- **sync-todoist-to-habitica: bump to 2026.03.25-343c793**
