### PR TITLE
media/sabnzbd: set memory requests/limits to 1536Mi

### DIFF
--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -61,10 +61,10 @@ spec:
                 sabnzbd.kalde.in
             resources:
               requests:
-                memory: 1000Mi
+                memory: 1536Mi
                 cpu: "1.5"
               limits:
-                memory: 2000Mi
+                memory: 1536Mi
                 cpu: "3"
 
     service:


### PR DESCRIPTION
Sets SABnzbd memory requests/limits to 1536Mi so it schedules with realistic headroom and avoids large spikes/overcommit.

- requests.memory: 1536Mi (was 1000Mi)
- limits.memory: 1536Mi (was 2000Mi)

CPU settings unchanged.