### PR TITLE
fix(home-assistant): pin to amd64 control-plane nodes

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -22,6 +22,13 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    # Pin to the amd64 control-plane nodes (k8s-cp-*). The arm64 Raspberry Pi
+    # workers boot HA slowly enough that the aiodns import races and aiohttp
+    # caches a broken DNS resolver for the whole process, breaking every
+    # network integration. The faster x86 nodes boot cleanly.
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/arch: amd64
     controllers:
       home-assistant:
         containers:


### PR DESCRIPTION
## Symptom
After any restart, HA floods the log with `RuntimeError: Resolver requires aiodns library` and a pile of integrations get stuck in `setup_error` (tplink/bar lights, meross, met/weather, hacs, simplisafe, smlight, analytics…). Reloading the entries returns HTTP 200 but doesn't recover them.

## Root cause
- aiodns/aiohttp are fine in isolation (`import aiodns` works; a fresh process sees the module).
- But the **running HA process** imported aiohttp's resolver during the boot storm on a **slow arm64 Pi**, the `aiodns` import raced/failed, and aiohttp cached `aiodns = None` **for the life of the process** → every DNS-using integration fails permanently, and reloads can't fix it.
- Every failure landed on a Pi (`pi-5`, then `pi-8`). Memory (1.5Gi) and version (2026.6.2) were ruled out.

## Fix
Pin HA to `kubernetes.io/arch=amd64` → the untainted, 8-core/12–16GB **control-plane** nodes. Faster boot avoids the race; amd64 also sidesteps any arm-specific quirk.

## After merge
Flux reschedules HA to a cp node and it reboots (~1–2 min). I'll verify the boot is clean (no resolver errors) and all integrations load.