### PR TITLE
fix(collabora): raise memory limit to prevent OOMKill during editing

### DIFF
--- a/kubernetes/apps/default/collabora/app/helmrelease.yaml
+++ b/kubernetes/apps/default/collabora/app/helmrelease.yaml
@@ -78,9 +78,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 256Mi
-              limits:
                 memory: 512Mi
+              limits:
+                memory: 2Gi
 
     service:
       app:


### PR DESCRIPTION
## Problem

Collabora loaded documents fine but **would not let you edit them**, with 404s visible in the browser network log.

## Root cause

Collabora was being **OOMKilled**, not a routing/WOPI problem.

- The container was `OOMKilled` (exit code 137) on `2026-06-14T17:45:36Z`.
- In steady state it sat at **~494Mi against the 512Mi limit** — pinned at the ceiling.
- Opening a doc renders cheaply (fits under the limit). Editing grows the per-document kit process past 512Mi → kernel kills the container → the **editing WebSocket drops** (continuous `Socket write returned -1 (ECONNRESET/EPIPE: Broken pipe)` in the coolwsd log). The WebSocket carries all editing/saves, so the doc stays viewable but un-editable, and in-flight requests 404.

Ruled out as causes: `/hosting/discovery` and `/hosting/capabilities` return 200, assets load, and OpenCloud's WOPI host grants `VIEW_MODE_READ_WRITE`. The `/wopi/avatars/...` and `/browser/.../images/*.svg` 404s are cosmetic.

## Fix

Raise the memory limit `512Mi → 2Gi` and request `256Mi → 512Mi` to give Collabora CODE headroom (already trimmed via `num_prespawn_children=1` / `per_document.max_concurrency=4`).

## Not included: frame_ancestors → CSP migration

coolwsd warns that `--o:net.frame_ancestors` is deprecated in favor of `net.content_security_policy`. I deliberately left this out: the CSP value (`frame-ancestors cloud.kalde.in;`) **requires a space**, but the image entrypoint expands `${extra_params}` unquoted (word-splits on spaces), and coolwsd's `--use-env-vars` only exports config *to* child processes — it can't read arbitrary config *from* env vars (verified against the running container). So there's no safe way to set it without overmounting `coolwsd.xml` (fragile across image upgrades). It's a future-removal warning and works today; not worth risking iframe embedding for.