### PR TITLE
feat(homepage): add gethomepage dashboard with Gateway API discovery

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -54,6 +54,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Home Assistant
+          gethomepage.dev/description: Home automation
+          gethomepage.dev/group: Home
+          gethomepage.dev/icon: home-assistant.png
+          gethomepage.dev/href: https://home-assistant.kalde.in
         hostnames: ["home-assistant.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app homepage
+  namespace: default
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: homepage
+  interval: 30m
+
+  values:
+    controllers:
+      homepage:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gethomepage/homepage
+              tag: v1.13.2
+            env:
+              # Homepage v1 rejects requests whose Host header is not allow-listed
+              HOMEPAGE_ALLOWED_HOSTS: homepage.kalde.in
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+        pod:
+          serviceAccountName: homepage
+
+    service:
+      app:
+        controller: homepage
+        ports:
+          http:
+            port: &port 3000
+
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.kalde.in"]
+        parentRefs:
+          - name: internal
+            namespace: kube-system
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+
+    persistence:
+      config:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /app/config
+      # Homepage writes request logs under /app/config/logs; keep it writable
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /app/config/logs
+
+    configMaps:
+      config:
+        data:
+          settings.yaml: |
+            title: Elmdon Cluster
+            headerStyle: clean
+            layout:
+              Infrastructure:
+                style: row
+                columns: 4
+              Media:
+                style: row
+                columns: 4
+              External:
+                style: row
+                columns: 4
+
+          # Cluster auto-discovery. Any Ingress or Gateway API HTTPRoute labelled
+          # `gethomepage.dev/enabled: "true"` is picked up automatically.
+          kubernetes.yaml: |
+            mode: cluster
+
+          widgets.yaml: |
+            - kubernetes:
+                cluster:
+                  show: true
+                  cpu: true
+                  memory: true
+                  showLabel: true
+                  label: cluster
+                nodes:
+                  show: true
+                  cpu: true
+                  memory: true
+                  showLabel: true
+            - resources:
+                backend: kubernetes
+                expanded: true
+                cpu: true
+                memory: true
+            - search:
+                provider: duckduckgo
+                target: _blank
+
+          # Externally-hosted apps: Docker VMs, NAS UIs, or any arbitrary URL.
+          # These live alongside the auto-discovered cluster services.
+          services.yaml: |
+            - External:
+                - Proxmox:
+                    href: https://192.168.10.2:8006
+                    description: Hypervisor
+                    icon: proxmox.png
+                - Example Docker App:
+                    href: http://192.168.10.50:8080
+                    description: App on a Docker VM
+                    icon: docker.png
+                - Synology NAS:
+                    href: https://192.168.10.3:5001
+                    description: DSM
+                    icon: synology.png
+
+          bookmarks.yaml: |
+            - Cluster:
+                - Repo:
+                    - abbr: GH
+                      href: https://github.com
+                - Grafana:
+                    - abbr: GR
+                      href: https://grafana.kalde.in
+
+          # Placeholder — add Docker socket/host integrations here if desired.
+          docker.yaml: |

--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -12,10 +12,18 @@ spec:
   interval: 30m
 
   values:
+    serviceAccount:
+      homepage: {}
+
     controllers:
       homepage:
         annotations:
           reloader.stakater.com/auto: "true"
+        serviceAccount:
+          identifier: homepage
+        pod:
+          # Homepage needs the SA token mounted to reach the Kubernetes API
+          automountServiceAccountToken: true
         containers:
           app:
             image:
@@ -30,8 +38,6 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 256Mi
-        pod:
-          serviceAccountName: homepage
 
     service:
       app:

--- a/kubernetes/apps/default/homepage/app/kustomization.yaml
+++ b/kubernetes/apps/default/homepage/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./rbac.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/homepage/app/ocirepository.yaml
+++ b/kubernetes/apps/default/homepage/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: homepage
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/homepage/app/rbac.yaml
+++ b/kubernetes/apps/default/homepage/app/rbac.yaml
@@ -1,9 +1,5 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: homepage
-  namespace: default
+# NOTE: the ServiceAccount itself is created by the app-template HelmRelease
+# (serviceAccount.homepage); this file only grants it cluster-wide read access.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/kubernetes/apps/default/homepage/app/rbac.yaml
+++ b/kubernetes/apps/default/homepage/app/rbac.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homepage
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homepage
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - nodes
+      - services
+    verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list"]
+  # Gateway API — required to auto-discover HTTPRoute-based apps
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+      - gateways
+      - httproutes
+    verbs: ["get", "list"]
+  # Metrics — powers the Kubernetes resource widget
+  - apiGroups: ["metrics.k8s.io"]
+    resources:
+      - nodes
+      - pods
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homepage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homepage
+subjects:
+  - kind: ServiceAccount
+    name: homepage
+    namespace: default

--- a/kubernetes/apps/default/homepage/ks.yaml
+++ b/kubernetes/apps/default/homepage/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-homepage
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/default/homepage/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -111,6 +111,13 @@ spec:
             port: 6379
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Immich
+          gethomepage.dev/description: Photo library
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: immich.png
+          gethomepage.dev/href: https://photos.kalde.in
         hostnames: ["photos.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./dailytxt/ks.yaml
   - ./filebrowser/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./homepage/ks.yaml
   - ./immich/ks.yaml
   - ./kapowarr/ks.yaml
   - ./kavita/ks.yaml

--- a/kubernetes/apps/default/linkding/app/helmrelease.yaml
+++ b/kubernetes/apps/default/linkding/app/helmrelease.yaml
@@ -34,6 +34,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Linkding
+          gethomepage.dev/description: Bookmark manager
+          gethomepage.dev/group: Infrastructure
+          gethomepage.dev/icon: linkding.png
+          gethomepage.dev/href: https://linkding.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/default/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mealie/app/helmrelease.yaml
@@ -85,6 +85,13 @@ spec:
             port: *port
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Mealie
+          gethomepage.dev/description: Recipe manager
+          gethomepage.dev/group: Home
+          gethomepage.dev/icon: mealie.png
+          gethomepage.dev/href: https://mealie.kalde.in
         hostnames: ["mealie.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -73,6 +73,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Paperless-ngx
+          gethomepage.dev/description: Document archive
+          gethomepage.dev/group: Infrastructure
+          gethomepage.dev/icon: paperless-ngx.png
+          gethomepage.dev/href: https://documents.kalde.in
         hostnames: ["documents.kalde.in"]
         parentRefs:
           - name: external


### PR DESCRIPTION
## What

Deploys [Homepage](https://gethomepage.dev) as a cluster dashboard.

- **app-template 5.0.1** HelmRelease, image `ghcr.io/gethomepage/homepage:v1.13.2`, config delivered via ConfigMap mounted at `/app/config` (writable `emptyDir` for logs), Reloader-annotated.
- **Read-only RBAC** (`ServiceAccount` + `ClusterRole` + binding): namespaces/pods/nodes/services, ingresses, and **`gateway.networking.k8s.io` httproutes+gateways** — the latter enables Gateway-API auto-discovery — plus metrics for the resource widget.
- **`kubernetes.yaml: mode: cluster`** — any Ingress/HTTPRoute labelled `gethomepage.dev/enabled: "true"` is discovered automatically.
- **Internal-only route** (`internal` gateway), so it's LAN-reachable at `homepage.kalde.in` but not exposed via Cloudflare. Homepage has no built-in auth.
- **External services group** in `services.yaml` for VM/Docker/arbitrary-URL apps (Synology is real; Proxmox + example Docker app are placeholders to edit).

## Discovery annotations

Added `gethomepage.dev/*` annotations to 5 HTTPRoutes as working examples: linkding + paperless-ngx (Infrastructure), home-assistant + mealie (Home), immich (Media). Remaining apps to be annotated separately.

## Validation

`kustomize build` passes for the new app and all edited app directories.