### PR TITLE
fix(homepage): keep /app/config writable (subPath mounts)

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -59,16 +59,31 @@ spec:
                 port: *port
 
     persistence:
+      # Mount each config file individually via subPath so /app/config itself
+      # stays writable — Homepage copies skeleton files (custom.css/js, logs)
+      # there on startup and fails with EROFS if the whole dir is a mount.
       config:
         type: configMap
         identifier: config
         globalMounts:
-          - path: /app/config
-      # Homepage writes request logs under /app/config/logs; keep it writable
-      logs:
-        type: emptyDir
-        globalMounts:
-          - path: /app/config/logs
+          - path: /app/config/settings.yaml
+            subPath: settings.yaml
+            readOnly: true
+          - path: /app/config/kubernetes.yaml
+            subPath: kubernetes.yaml
+            readOnly: true
+          - path: /app/config/widgets.yaml
+            subPath: widgets.yaml
+            readOnly: true
+          - path: /app/config/services.yaml
+            subPath: services.yaml
+            readOnly: true
+          - path: /app/config/bookmarks.yaml
+            subPath: bookmarks.yaml
+            readOnly: true
+          - path: /app/config/docker.yaml
+            subPath: docker.yaml
+            readOnly: true
 
     configMaps:
       config:


### PR DESCRIPTION
## Problem

Homepage crash-loops on startup after #373 deployed:

```
error: ❌ Failed to initialize required config: /app/config/custom.css
Reason: EROFS: read-only file system, copyfile '/app/src/skeleton/custom.css' -> '/app/config/custom.css'
```

Homepage's entrypoint copies skeleton files (`custom.css`, `custom.js`, the `logs/` dir) into `/app/config` at boot. Mounting the whole ConfigMap at `/app/config` made the directory read-only, so the copy failed.

## Fix

Mount each config file individually via `subPath` (`settings.yaml`, `kubernetes.yaml`, `widgets.yaml`, `services.yaml`, `bookmarks.yaml`, `docker.yaml`). `subPath` mounts don't make the parent read-only, so `/app/config` stays writable for the skeleton files and logs. Dropped the separate `logs` emptyDir — no longer needed. Reloader still restarts the pod on ConfigMap changes.

Verified with `helm template ... app-template 5.0.1` — renders six file mounts, dir no longer a mount point.