### PR TITLE
fix(homepage): enable Gateway API discovery

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -106,6 +106,7 @@ spec:
           # `gethomepage.dev/enabled: "true"` is picked up automatically.
           kubernetes.yaml: |
             mode: cluster
+            gateway: true
 
           widgets.yaml: |
             - kubernetes:


### PR DESCRIPTION
## Problem

Homepage runs fine but shows none of the cluster apps, despite correct RBAC and `gethomepage.dev/*` annotations on the HTTPRoutes (verified live: SA can list httproutes, 5 routes carry the annotations).

## Cause

`kubernetes.yaml` had only `mode: cluster`, which scans **Ingress** resources. This cluster routes everything through **Gateway API HTTPRoutes** and has no Ingresses, so discovery found nothing. Per the [Homepage docs](https://gethomepage.dev/configs/kubernetes/), HTTPRoute discovery requires an explicit toggle.

## Fix

```yaml
kubernetes.yaml: |
  mode: cluster
  gateway: true   # <- read Gateway API HTTPRoutes
```

No other changes needed — annotations, RBAC (`gateway.networking.k8s.io` httproutes/gateways), and the internal-only route are already in place.