### PR TITLE
feat(homepage): annotate media apps for discovery

### DIFF
--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -87,6 +87,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Lidarr
+          gethomepage.dev/description: Music management
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: lidarr.png
+          gethomepage.dev/href: https://lidarr.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/navidrome/app/helmrelease.yaml
+++ b/kubernetes/apps/media/navidrome/app/helmrelease.yaml
@@ -75,6 +75,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Navidrome
+          gethomepage.dev/description: Music streaming
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: navidrome.png
+          gethomepage.dev/href: https://navidrome.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -73,6 +73,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Radarr
+          gethomepage.dev/description: Movie management
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: radarr.png
+          gethomepage.dev/href: https://radarr.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in", "radarr.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -75,6 +75,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: SABnzbd
+          gethomepage.dev/description: Usenet downloader
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: sabnzbd.png
+          gethomepage.dev/href: https://sabnzbd.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -50,6 +50,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Jellyseerr
+          gethomepage.dev/description: Media requests
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: jellyseerr.png
+          gethomepage.dev/href: https://seerr.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -68,6 +68,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Sonarr
+          gethomepage.dev/description: TV series management
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: sonarr.png
+          gethomepage.dev/href: https://sonarr.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in", "sonarr.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -55,6 +55,13 @@ spec:
 
     route:
       app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Tautulli
+          gethomepage.dev/description: Plex statistics
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: tautulli.png
+          gethomepage.dev/href: https://tautulli.kalde.in
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external


### PR DESCRIPTION
Adds `gethomepage.dev/*` discovery annotations to the media stack so Homepage surfaces them in a **Media** group:

- **sabnzbd** — Usenet downloader
- **sonarr** — TV series management
- **radarr** — movie management
- **lidarr** — music management
- **navidrome** — music streaming
- **seerr** (Jellyseerr) — media requests
- **tautulli** — Plex statistics

Same mechanism as the apps in #373 — discovery already works after the `gateway: true` fix (#375). `kustomize build` passes for all seven.

> Note: these are bare links. The *arr apps, sabnzbd, jellyseerr, and tautulli all have rich Homepage widgets (queue counts, stats) — those need each app's API key wired in via a secret. Happy to follow up with that if wanted.