### PR TITLE
feat(homepage): Radarr + Lidarr service widgets

### DIFF
--- a/kubernetes/apps/default/homepage/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homepage/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homepage
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: homepage-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Service-widget API keys, consumed via {{HOMEPAGE_VAR_*}} in widget annotations
+        HOMEPAGE_VAR_RADARR_API_KEY: "{{ .RADARR__API_KEY }}"
+        HOMEPAGE_VAR_LIDARR_API_KEY: "{{ .LIDARR__API_KEY }}"
+  dataFrom:
+    - extract:
+        key: radarr
+    - extract:
+        key: lidarr

--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -32,6 +32,10 @@ spec:
             env:
               # Homepage v1 rejects requests whose Host header is not allow-listed
               HOMEPAGE_ALLOWED_HOSTS: homepage.kalde.in
+            envFrom:
+              # Service-widget API keys -> {{HOMEPAGE_VAR_*}} substitution
+              - secretRef:
+                  name: homepage-secret
             resources:
               requests:
                 cpu: 10m

--- a/kubernetes/apps/default/homepage/app/kustomization.yaml
+++ b/kubernetes/apps/default/homepage/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 namespace: default
 resources:
   - ./rbac.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -96,7 +96,8 @@ spec:
           gethomepage.dev/href: https://lidarr.kalde.in
           gethomepage.dev/widget.type: lidarr
           gethomepage.dev/widget.url: http://lidarr.media.svc.cluster.local:8686
-          gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_LIDARR_API_KEY}}"
+          # Escaped so app-template's tpl pass emits the literal placeholder for Homepage
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_LIDARR_API_KEY}}" }}'
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -94,6 +94,9 @@ spec:
           gethomepage.dev/group: Media
           gethomepage.dev/icon: lidarr.png
           gethomepage.dev/href: https://lidarr.kalde.in
+          gethomepage.dev/widget.type: lidarr
+          gethomepage.dev/widget.url: http://lidarr.media.svc.cluster.local:8686
+          gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_LIDARR_API_KEY}}"
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -80,6 +80,9 @@ spec:
           gethomepage.dev/group: Media
           gethomepage.dev/icon: radarr.png
           gethomepage.dev/href: https://radarr.kalde.in
+          gethomepage.dev/widget.type: radarr
+          gethomepage.dev/widget.url: http://radarr.media.svc.cluster.local
+          gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_RADARR_API_KEY}}"
         hostnames: ["{{ .Release.Name }}.kalde.in", "radarr.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -82,7 +82,8 @@ spec:
           gethomepage.dev/href: https://radarr.kalde.in
           gethomepage.dev/widget.type: radarr
           gethomepage.dev/widget.url: http://radarr.media.svc.cluster.local
-          gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_RADARR_API_KEY}}"
+          # Escaped so app-template's tpl pass emits the literal placeholder for Homepage
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_RADARR_API_KEY}}" }}'
         hostnames: ["{{ .Release.Name }}.kalde.in", "radarr.kalde.in"]
         parentRefs:
           - name: external


### PR DESCRIPTION
Adds live-status widgets for Radarr and Lidarr (the two apps whose API keys are already in 1Password).

## Plumbing

- **New ExternalSecret** (`default/homepage` → `homepage-secret`) pulls `RADARR__API_KEY` and `LIDARR__API_KEY` from the existing `radarr`/`lidarr` 1Password items via `onepassword-connect`, exposing them as `HOMEPAGE_VAR_RADARR_API_KEY` / `HOMEPAGE_VAR_LIDARR_API_KEY`.
- **Homepage pod** gets `envFrom: homepage-secret`, so `{{HOMEPAGE_VAR_*}}` substitution works.
- **Widget annotations** on the radarr/lidarr HTTPRoutes:
  - `radarr` → `http://radarr.media.svc.cluster.local`
  - `lidarr` → `http://lidarr.media.svc.cluster.local:8686`
  - key = `{{HOMEPAGE_VAR_<APP>_API_KEY}}`

Reloader restarts the pod when `homepage-secret` changes.

## Not included

sonarr, sabnzbd, jellyseerr, tautulli — their keys aren't in 1Password yet, so they stay as plain links for now.

## Validation

`kustomize build` passes for all three dirs; `helm template` of the Homepage HelmRelease renders cleanly with the new `envFrom`.