### PR TITLE
fix(homepage): define Radarr/Lidarr widgets in services.yaml

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -137,6 +137,28 @@ spec:
           # Externally-hosted apps: Docker VMs, NAS UIs, or any arbitrary URL.
           # These live alongside the auto-discovered cluster services.
           services.yaml: |
+            # Widget API keys can only be substituted in config files, not in
+            # Kubernetes annotations, so these two live here instead of via
+            # auto-discovery. The backtick wrapper escapes app-templates own
+            # tpl pass; Homepage resolves the inner placeholder from the
+            # envFrom secret at runtime.
+            - Media:
+                - Radarr:
+                    href: https://radarr.kalde.in
+                    description: Movie management
+                    icon: radarr.png
+                    widget:
+                      type: radarr
+                      url: http://radarr.media.svc.cluster.local
+                      key: "{{ `{{HOMEPAGE_VAR_RADARR_API_KEY}}` }}"
+                - Lidarr:
+                    href: https://lidarr.kalde.in
+                    description: Music management
+                    icon: lidarr.png
+                    widget:
+                      type: lidarr
+                      url: http://lidarr.media.svc.cluster.local:8686
+                      key: "{{ `{{HOMEPAGE_VAR_LIDARR_API_KEY}}` }}"
             - External:
                 - Proxmox:
                     href: https://192.168.10.2:8006

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -87,17 +87,8 @@ spec:
 
     route:
       app:
-        annotations:
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/name: Lidarr
-          gethomepage.dev/description: Music management
-          gethomepage.dev/group: Media
-          gethomepage.dev/icon: lidarr.png
-          gethomepage.dev/href: https://lidarr.kalde.in
-          gethomepage.dev/widget.type: lidarr
-          gethomepage.dev/widget.url: http://lidarr.media.svc.cluster.local:8686
-          # Escaped so app-template's tpl pass emits the literal placeholder for Homepage
-          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_LIDARR_API_KEY}}" }}'
+        # Defined in Homepage's services.yaml (with widget) instead of via
+        # discovery, since widget API keys can't be templated in annotations.
         hostnames: ["{{ .Release.Name }}.kalde.in"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -73,17 +73,8 @@ spec:
 
     route:
       app:
-        annotations:
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/name: Radarr
-          gethomepage.dev/description: Movie management
-          gethomepage.dev/group: Media
-          gethomepage.dev/icon: radarr.png
-          gethomepage.dev/href: https://radarr.kalde.in
-          gethomepage.dev/widget.type: radarr
-          gethomepage.dev/widget.url: http://radarr.media.svc.cluster.local
-          # Escaped so app-template's tpl pass emits the literal placeholder for Homepage
-          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_RADARR_API_KEY}}" }}'
+        # Defined in Homepage's services.yaml (with widget) instead of via
+        # discovery, since widget API keys can't be templated in annotations.
         hostnames: ["{{ .Release.Name }}.kalde.in", "radarr.kalde.in"]
         parentRefs:
           - name: external


### PR DESCRIPTION
## Problem

Radarr/Lidarr widgets rendered but every API call returned **401**. Proven from inside the Homepage pod:

```
real key     -> HTTP/1.1 200 OK
literal {{}} -> HTTP/1.1 401 Unauthorized
```

The env var is set correctly and its value matches the apps' live API keys — but Homepage **does not substitute `{{HOMEPAGE_VAR_*}}` inside Kubernetes-discovered annotations**, only in config files ([docs confirm](https://gethomepage.dev/configs/kubernetes/)). So it sent the literal `{{HOMEPAGE_VAR_RADARR_API_KEY}}` as the key.

## Fix

- Define Radarr + Lidarr (with widgets) in Homepage's `services.yaml`, where `{{HOMEPAGE_VAR_*}}` substitution works.
- Remove their discovery annotations so they aren't shown twice.
- The `key` uses a backtick-escape (`"{{ \`{{HOMEPAGE_VAR_X}}\` }}"`) so app-template's own `tpl` pass emits the literal placeholder for Homepage to resolve at runtime.

Verified by rendering the chart and parsing the ConfigMap: `key = '{{HOMEPAGE_VAR_RADARR_API_KEY}}'` for both.

## Note

This makes Radarr/Lidarr config-defined rather than auto-discovered — a necessary trade-off for widgets needing secret keys. The other media apps stay on annotation discovery (plain links).