### PR TITLE
fix(teslamate): enable Grafana metrics

### DIFF
--- a/kubernetes/apps/default/teslamate/grafana/helmrelease.yaml
+++ b/kubernetes/apps/default/teslamate/grafana/helmrelease.yaml
@@ -35,6 +35,8 @@ spec:
               tag: 3.1
             env:
               DATABASE_HOST: postgres17-rw.database.svc.cluster.local
+              GF_METRICS_ENABLED: "true"
+              GF_METRICS_DISABLE_TOTAL_STATS: "true"
             envFrom:
               - secretRef:
                   name: teslamate-secret
@@ -56,8 +58,7 @@ spec:
         enabled: true
         endpoints:
           - port: http
-
-
+            path: /metrics
 
     route:
       app:


### PR DESCRIPTION
## Summary
- enable Grafana metrics for the teslamate-grafana container
- make the ServiceMonitor scrape `/metrics` explicitly

## Validation
- parsed `kubernetes/apps/default/teslamate/grafana/helmrelease.yaml` with PyYAML

## Context
Prometheus was alerting `TargetDown` for `teslamate-grafana/teslamate-grafana`. The ServiceMonitor was already enabled, but Grafana metrics were not enabled in the container environment, so the scrape endpoint was not available.