### PR TITLE
feat(security): add Authentik SSO (phase 0)

### DIFF
--- a/kubernetes/apps/security/authentik/app/externalsecret.yaml
+++ b/kubernetes/apps/security/authentik/app/externalsecret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # authentik application secret key
+        AUTHENTIK_SECRET_KEY: "{{ .AUTHENTIK_SECRET_KEY }}"
+        # bootstrap the initial akadmin user (consumed on first install only)
+        AUTHENTIK_BOOTSTRAP_PASSWORD: "{{ .AUTHENTIK_BOOTSTRAP_PASSWORD }}"
+        AUTHENTIK_BOOTSTRAP_TOKEN: "{{ .AUTHENTIK_BOOTSTRAP_TOKEN }}"
+        AUTHENTIK_BOOTSTRAP_EMAIL: "{{ .AUTHENTIK_BOOTSTRAP_EMAIL }}"
+        # database password (server + worker connect as the authentik role)
+        AUTHENTIK_POSTGRESQL__PASSWORD: "{{ .POSTGRES_PASS }}"
+        # postgres-init initContainer: creates the db + role using superuser creds
+        INIT_POSTGRES_DBNAME: authentik
+        INIT_POSTGRES_HOST: postgres17-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: authentik
+        INIT_POSTGRES_PASS: "{{ .POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: authentik
+    - extract:
+        key: cloudnative-pg
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik
+  namespace: security
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: authentik
+      version: 2026.5.3
+      sourceRef:
+        kind: HelmRepository
+        name: authentik
+        namespace: security
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    - name: authentik-redis
+      namespace: security
+  values:
+    global:
+      # AUTHENTIK_SECRET_KEY, AUTHENTIK_BOOTSTRAP_*, AUTHENTIK_POSTGRESQL__PASSWORD
+      envFrom:
+        - secretRef:
+            name: authentik-secret
+    authentik:
+      log_level: info
+      error_reporting:
+        enabled: false
+      postgresql:
+        host: postgres17-rw.database.svc.cluster.local
+        name: authentik
+        user: authentik
+      redis:
+        host: authentik-redis-app.security.svc.cluster.local
+    # bundled Bitnami PostgreSQL subchart disabled — we use CloudNative-PG
+    postgresql:
+      enabled: false
+    server:
+      replicas: 1
+      initContainers:
+        # creates the authentik database + role before the server starts
+        - name: init-db
+          image: ghcr.io/home-operations/postgres-init:17.6
+          envFrom:
+            - secretRef:
+                name: authentik-secret
+      ingress:
+        enabled: false
+      metrics:
+        enabled: false
+    worker:
+      replicas: 1

--- a/kubernetes/apps/security/authentik/app/helmrepository.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: authentik
+  namespace: security
+spec:
+  interval: 2h
+  url: https://charts.goauthentik.io

--- a/kubernetes/apps/security/authentik/app/httproute.yaml
+++ b/kubernetes/apps/security/authentik/app/httproute.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authentik
+  namespace: security
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Authentik
+    gethomepage.dev/description: Single Sign-On
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: authentik.png
+    gethomepage.dev/href: https://auth.kalde.in
+spec:
+  hostnames:
+    - auth.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./redis.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/security/authentik/app/ocirepository.yaml
+++ b/kubernetes/apps/security/authentik/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: authentik-redis
+  namespace: security
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/security/authentik/app/redis.yaml
+++ b/kubernetes/apps/security/authentik/app/redis.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik-redis
+  namespace: security
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: authentik-redis
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      redis:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/valkey/valkey
+              tag: 9.1.0-trixie
+            command:
+              - valkey-server
+              - --save
+              - "60 1"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1024
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: "OnRootMismatch"
+    service:
+      app:
+        controller: redis
+        ports:
+          http:
+            port: 6379
+    persistence:
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/security/authentik/ks.yaml
+++ b/kubernetes/apps/security/authentik/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-authentik
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-cloudnative-pg-cluster-17
+    - name: cluster-apps-external-secrets-stores
+  path: ./kubernetes/apps/security/authentik/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./authentik/ks.yaml

--- a/kubernetes/apps/security/namespace.yaml
+++ b/kubernetes/apps/security/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: security
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/enabled: "false"


### PR DESCRIPTION
## Phase 0 — Authentik foundation

Stands up **Authentik** as the cluster identity provider, exposed at `auth.kalde.in` on **both** the `external` and `internal` gateways so single sign-on works identically over Cloudflare and the LAN (split-horizon DNS). This is the foundation for migrating apps off their individual logins, one at a time.

### What's included
- **HelmRelease** — official Authentik chart `2026.5.3`. Connects to the existing shared `postgres17` CloudNative-PG cluster; the `authentik` database + role are created by a `postgres-init` initContainer (same pattern as Immich et al.). Bundled Bitnami Postgres disabled.
- **Valkey** (bjw-s `app-template`) for Redis — the chart no longer bundles one.
- **ExternalSecret** — pulls the `authentik` 1Password item (`AUTHENTIK_SECRET_KEY`, bootstrap admin creds, `POSTGRES_PASS`) plus the existing `cloudnative-pg` superuser item.
- **HTTPRoute** — `auth.kalde.in` on the external + internal gateways.
- New `security` namespace, auto-discovered by `cluster-apps`.

### Notes
- Uses the shared `postgres17` cluster (no new DB cluster).
- Valkey persistence is `emptyDir` (cache/broker only) — sessions reset if the Redis pod restarts; easy to move to a PVC later.

### Validation
- `kustomize build` passes on the `security`, `authentik/app`, and `database` overlays.
- `kubeconform` clean (CRD-backed kinds skipped offline).

### Follow-up
Phase 1 begins with migrating **Miniflux** to native OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)