### PR TITLE
feat(miniflux): sign in with Authentik (OIDC)

### DIFF
--- a/kubernetes/apps/default/miniflux/app/externalsecret.yaml
+++ b/kubernetes/apps/default/miniflux/app/externalsecret.yaml
@@ -19,6 +19,9 @@ spec:
         ADMIN_USERNAME: "{{ .ADMIN_USERNAME }}"
         ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"
         DATABASE_URL: "postgres://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@postgres17-rw.database.svc.cluster.local/miniflux?sslmode=disable"
+        # SSO (Authentik OAuth2 client — must match the blueprint)
+        OAUTH2_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
+        OAUTH2_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
         # Postgres Init
         INIT_POSTGRES_DBNAME: miniflux
         INIT_POSTGRES_HOST: postgres17-rw.database.svc.cluster.local

--- a/kubernetes/apps/default/miniflux/app/helmrelease.yaml
+++ b/kubernetes/apps/default/miniflux/app/helmrelease.yaml
@@ -51,6 +51,12 @@ spec:
               POLLING_SCHEDULER: entry_frequency
               POLLING_FREQUENCY: "15"
               RUN_MIGRATIONS: "1"
+              # SSO via Authentik (client id/secret come from miniflux-secret)
+              OAUTH2_PROVIDER: oidc
+              OAUTH2_OIDC_PROVIDER_NAME: Authentik
+              OAUTH2_OIDC_DISCOVERY_ENDPOINT: https://auth.kalde.in/application/o/miniflux/
+              OAUTH2_REDIRECT_URL: https://rss.kalde.in/oauth2/oidc/callback
+              OAUTH2_USER_CREATION: "1"
             envFrom: *envFrom
             probes:
               liveness: &probes

--- a/kubernetes/apps/security/authentik/app/blueprints/miniflux.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/miniflux.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-miniflux
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-miniflux
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      # the worker discovers and applies any ".yaml" key in this secret
+      data:
+        miniflux.yaml: |
+          version: 1
+          metadata:
+            name: miniflux
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-miniflux
+              state: present
+              identifiers:
+                name: miniflux
+              attrs:
+                name: miniflux
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                redirect_uris:
+                  - url: https://rss.kalde.in/oauth2/oidc/callback
+                    matching_mode: strict
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-miniflux
+              state: present
+              identifiers:
+                slug: miniflux
+              attrs:
+                name: Miniflux
+                slug: miniflux
+                provider: !KeyOf provider-miniflux
+                meta_launch_url: https://rss.kalde.in
+                meta_description: Minimalist RSS reader
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: miniflux
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -48,6 +48,10 @@ spec:
     # bundled Bitnami PostgreSQL subchart disabled — we use CloudNative-PG
     postgresql:
       enabled: false
+    # per-app SSO definitions, applied by the worker (see ./blueprints/)
+    blueprints:
+      secrets:
+        - authentik-blueprint-miniflux
     server:
       replicas: 1
       initContainers:

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - ./redis.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  # per-app SSO blueprints (provider + application definitions)
+  - ./blueprints/miniflux.yaml


### PR DESCRIPTION
## Phase 1 — first app on SSO: Miniflux

Makes Miniflux an OAuth2/OIDC client of Authentik. This is the proof-of-concept for the blueprint-driven pattern we'll repeat across the other OIDC-capable apps.

### Authentik side (`security` ns)
- New declarative **blueprint** (`blueprints/miniflux.yaml`) creating an OAuth2 provider + application (slug `miniflux`, redirect `https://rss.kalde.in/oauth2/oidc/callback`).
- Delivered as an **ESO-rendered Secret** (`blueprints.secrets`), so the client secret comes from 1Password and never lands in Git.

### Miniflux side (`default` ns)
- `OAUTH2_PROVIDER=oidc` pointed at `https://auth.kalde.in/application/o/miniflux/`.
- Client ID/secret added to the existing `miniflux-secret` externalsecret.

### Requires (before merge)
Add two fields to the existing **`miniflux`** 1Password item:
- `OAUTH_CLIENT_ID`
- `OAUTH_CLIENT_SECRET`

### Rollout note
Local login stays enabled in this PR. After confirming SSO works (and linking your Authentik user to the Miniflux account), a one-line follow-up sets `DISABLE_LOCAL_AUTH=1` to make Authentik the sole login.

### Validation
`kustomize build` passes on the `security/authentik/app` and `default/miniflux/app` overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)