### PR TITLE
fix(authentik): enable grant_types on miniflux oauth2 provider

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/miniflux.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/miniflux.yaml
@@ -35,6 +35,11 @@ spec:
                 client_type: confidential
                 client_id: "{{ .OAUTH_CLIENT_ID }}"
                 client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                # 2026.5+: blueprint-created providers default to an empty
+                # grant_types list, which blocks the auth-code flow. Set it.
+                grant_types:
+                  - authorization_code
+                  - refresh_token
                 redirect_uris:
                   - url: https://rss.kalde.in/oauth2/oidc/callback
                     matching_mode: strict


### PR DESCRIPTION
## Fix: Miniflux SSO "No code received on OAuth2 callback"

After #392 merged, clicking "Sign in with Authentik" bounced back to Miniflux with no auth code.

### Root cause
Authentik **2026.5** added an explicit per-provider **`grant_types`** field (`ArrayField`, `default=list`). Providers created via the **UI** default to all grant types enabled, but a provider created via **blueprint/API without the field** starts with an **empty list** — so the authorization-code flow is rejected:

```
Invalid grant_type for provider   grant_type=authorization_code
The request is otherwise malformed
```

Authentik then 302s back to the redirect_uri with an error instead of a `code`, and Miniflux logs `No code received on OAuth2 callback`.

### Fix
Set `grant_types: [authorization_code, refresh_token]` on the Miniflux provider blueprint. On merge, ESO re-renders the blueprint Secret and the worker re-applies it automatically.

**Note for future app blueprints:** every OAuth2 provider blueprint needs this field on 2026.5+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)