### PR TITLE
feat(miniflux): make Authentik the only login

### DIFF
--- a/kubernetes/apps/default/miniflux/app/helmrelease.yaml
+++ b/kubernetes/apps/default/miniflux/app/helmrelease.yaml
@@ -43,7 +43,8 @@ spec:
               tag: 2.3.1
             env:
               BASE_URL: https://rss.kalde.in
-              CREATE_ADMIN: "1"
+              # local admin already exists and local auth is disabled below
+              CREATE_ADMIN: "0"
               DEBUG: "1"
               LOG_DATE_TIME: "1"
               METRICS_ALLOWED_NETWORKS: "10.32.0.0/16"
@@ -56,7 +57,10 @@ spec:
               OAUTH2_OIDC_PROVIDER_NAME: Authentik
               OAUTH2_OIDC_DISCOVERY_ENDPOINT: https://auth.kalde.in/application/o/miniflux/
               OAUTH2_REDIRECT_URL: https://rss.kalde.in/oauth2/oidc/callback
-              OAUTH2_USER_CREATION: "1"
+              # single-user app: account is linked, so no auto-provisioning
+              OAUTH2_USER_CREATION: "0"
+              # Authentik is now the only login (no local username/password form)
+              DISABLE_LOCAL_AUTH: "1"
             envFrom: *envFrom
             probes:
               liveness: &probes


### PR DESCRIPTION
## Lock Miniflux to SSO

Account linking is confirmed — Authentik logins resolve to the existing `user_id=1` (admin) with all data intact. This flips Miniflux to Authentik-only.

- `DISABLE_LOCAL_AUTH=1` — removes the local username/password form; only "Sign in with Authentik" remains.
- `OAUTH2_USER_CREATION=0` — single-user app, no stray auto-provisioned accounts.
- `CREATE_ADMIN=0` — the admin already exists and is contradictory with local auth disabled.

### Not affected
API-key access (e.g. the Homepage widget, any integrations) is independent of the login form and keeps working.

### Break-glass
If Authentik is ever down, UI login is unavailable until it recovers (or revert this commit / re-enable local auth via Git). API keys still work regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)