### PR TITLE
feat(linkding): sign in with Authentik (OIDC)

### DIFF
--- a/kubernetes/apps/default/linkding/app/externalsecret.yaml
+++ b/kubernetes/apps/default/linkding/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: linkding
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: linkding-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Authentik OAuth2 client (must match the blueprint)
+        OIDC_RP_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
+        OIDC_RP_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: linkding
+  refreshInterval: 5m

--- a/kubernetes/apps/default/linkding/app/helmrelease.yaml
+++ b/kubernetes/apps/default/linkding/app/helmrelease.yaml
@@ -14,11 +14,27 @@ spec:
   values:
     controllers:
       linkding:
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
               repository: sissbruecker/linkding
               tag: 1.45.0
+            env:
+              # SSO via Authentik. Linkding matches/links the account by
+              # email, so the existing Linkding user's email must equal the
+              # Authentik user's email. Client id/secret come from the secret.
+              LD_ENABLE_OIDC: "True"
+              OIDC_OP_AUTHORIZATION_ENDPOINT: https://auth.kalde.in/application/o/authorize/
+              OIDC_OP_TOKEN_ENDPOINT: https://auth.kalde.in/application/o/token/
+              OIDC_OP_USER_ENDPOINT: https://auth.kalde.in/application/o/userinfo/
+              OIDC_OP_JWKS_ENDPOINT: https://auth.kalde.in/application/o/linkding/jwks/
+              OIDC_RP_SIGN_ALGO: RS256
+              OIDC_RP_SCOPES: "openid profile email"
+            envFrom:
+              - secretRef:
+                  name: linkding-secret
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/apps/default/linkding/app/kustomization.yaml
+++ b/kubernetes/apps/default/linkding/app/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: default
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/linkding.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/linkding.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-linkding
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-linkding
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        linkding.yaml: |
+          version: 1
+          metadata:
+            name: linkding
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-linkding
+              state: present
+              identifiers:
+                name: linkding
+              attrs:
+                name: linkding
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                # 2026.5+: blueprint-created providers default to an empty
+                # grant_types list, which blocks the auth-code flow. Set it.
+                grant_types:
+                  - authorization_code
+                  - refresh_token
+                redirect_uris:
+                  - url: https://linkding.kalde.in/oidc/callback/
+                    matching_mode: strict
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-linkding
+              state: present
+              identifiers:
+                slug: linkding
+              attrs:
+                name: Linkding
+                slug: linkding
+                provider: !KeyOf provider-linkding
+                meta_launch_url: https://linkding.kalde.in
+                meta_description: Bookmark manager
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: linkding
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
     blueprints:
       secrets:
         - authentik-blueprint-miniflux
+        - authentik-blueprint-linkding
     server:
       replicas: 1
       initContainers:

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./httproute.yaml
   # per-app SSO blueprints (provider + application definitions)
   - ./blueprints/miniflux.yaml
+  - ./blueprints/linkding.yaml


### PR DESCRIPTION
## Phase 1 — app #2: Linkding

Adds Linkding as an OIDC client of Authentik, reusing the Miniflux pattern (with `grant_types` set on the provider up front, per the lesson from #393).

### Authentik side (`security` ns)
- New blueprint `blueprints/linkding.yaml` (provider + application, slug `linkding`, redirect `https://linkding.kalde.in/oidc/callback/`), delivered as an ESO-rendered Secret.

### Linkding side (`default` ns)
- `LD_ENABLE_OIDC=True` with explicit Authentik endpoints (Linkding uses mozilla-django-oidc — no discovery shortcut, so authorization/token/userinfo/jwks are set individually).
- New `linkding-secret` externalsecret for the client id/secret; `reloader` annotation so it restarts on sync.

### Requires (before merge)
Create a new **`linkding`** 1Password item with:
- `OAUTH_CLIENT_ID`
- `OAUTH_CLIENT_SECRET`

### Account linking — important
Linkding **auto-matches by email** (no in-app "link" step). Before/right after enabling, make sure your **existing Linkding account's email = your Authentik email** (`uhclay@gmail.com`). If they match, OIDC login lands on your existing account with all bookmarks. If the existing account has a different/empty email, the first OIDC login would create a *new* account instead.

### Note
Linkding has no clean "disable local auth" toggle, so the local login form stays as a break-glass fallback alongside the SSO button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)