### PR TITLE
feat(changedetection): gate behind Authentik proxy outpost (forward-auth)

### DIFF
--- a/kubernetes/apps/default/changedetection/app/helmrelease.yaml
+++ b/kubernetes/apps/default/changedetection/app/helmrelease.yaml
@@ -44,22 +44,11 @@ spec:
       app:
         ports:
           http:
-            port: &port 5000
+            port: 5000
 
-    route:
-      app:
-        hostnames: ["{{ .Release.Name }}.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: changedetection has no OIDC, so it is exposed only via
+    # the Authentik embedded proxy outpost. See ./httproute.yaml, which sends
+    # changedetection.kalde.in to authentik-server (the outpost) instead.
 
     persistence:
       datastore:

--- a/kubernetes/apps/default/changedetection/app/httproute.yaml
+++ b/kubernetes/apps/default/changedetection/app/httproute.yaml
@@ -1,0 +1,33 @@
+---
+# changedetection is fronted by the Authentik embedded proxy outpost: route
+# the public host to authentik-server (security ns), which authenticates and
+# then proxies to the changedetection Service internally. Cross-namespace
+# backendRef is permitted by the ReferenceGrant in the security namespace.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: changedetection
+  namespace: default
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Changedetection
+    gethomepage.dev/description: Website change monitor
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: changedetection.png
+    gethomepage.dev/href: https://changedetection.kalde.in
+spec:
+  hostnames:
+    - changedetection.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/changedetection/app/kustomization.yaml
+++ b/kubernetes/apps/default/changedetection/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./datastore-pvc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/changedetection.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/changedetection.yaml
@@ -1,0 +1,40 @@
+---
+# Proxy provider + application for changedetection (no native OIDC, so it is
+# gated by the Authentik embedded proxy outpost). No client secret involved,
+# so this ships as a plain ConfigMap rather than an ESO-rendered Secret.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-changedetection
+  namespace: security
+data:
+  changedetection.yaml: |
+    version: 1
+    metadata:
+      name: changedetection
+    entries:
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-changedetection
+        state: present
+        identifiers:
+          name: changedetection
+        attrs:
+          name: changedetection
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://changedetection.kalde.in
+          internal_host: http://changedetection.default.svc.cluster.local:5000
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-changedetection
+        state: present
+        identifiers:
+          slug: changedetection
+        attrs:
+          name: Changedetection
+          slug: changedetection
+          provider: !KeyOf provider-changedetection
+          meta_launch_url: https://changedetection.kalde.in
+          meta_description: Website change monitor
+          policy_engine_mode: any

--- a/kubernetes/apps/security/authentik/app/blueprints/proxy-outpost.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/proxy-outpost.yaml
@@ -1,0 +1,22 @@
+---
+# Central registry: which proxy providers the embedded outpost serves.
+# The outpost.providers list is a single shared list, so it is managed here
+# rather than per-app. Add one !Find line per forward-auth app.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-proxy-outpost
+  namespace: security
+data:
+  proxy-outpost.yaml: |
+    version: 1
+    metadata:
+      name: proxy-outpost-providers
+    entries:
+      - model: authentik_outposts.outpost
+        state: present
+        identifiers:
+          name: authentik Embedded Outpost
+        attrs:
+          providers:
+            - !Find [authentik_providers_proxy.proxyprovider, [name, changedetection]]

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -53,6 +53,9 @@ spec:
       secrets:
         - authentik-blueprint-miniflux
         - authentik-blueprint-linkding
+      configMaps:
+        - authentik-blueprint-changedetection
+        - authentik-blueprint-proxy-outpost
     server:
       replicas: 1
       initContainers:

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
   - ./redis.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./referencegrant.yaml
   # per-app SSO blueprints (provider + application definitions)
   - ./blueprints/miniflux.yaml
   - ./blueprints/linkding.yaml
+  # forward-auth (proxy outpost) apps
+  - ./blueprints/changedetection.yaml
+  - ./blueprints/proxy-outpost.yaml

--- a/kubernetes/apps/security/authentik/app/referencegrant.yaml
+++ b/kubernetes/apps/security/authentik/app/referencegrant.yaml
@@ -1,0 +1,17 @@
+---
+# Allow HTTPRoutes in the default namespace (proxied apps) to send traffic to
+# the authentik-server Service, which runs the embedded proxy outpost.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: default-to-authentik-server
+  namespace: security
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ""
+      kind: Service
+      name: authentik-server


### PR DESCRIPTION
## Phase 1 — app #3: changedetection (first **forward-auth** app)

changedetection has no OIDC (just an optional single password), so it can't use the login-integration pattern. Instead it's gated by **Authentik's embedded proxy outpost**, which becomes its reverse proxy. This establishes the pattern for the remaining no-OIDC apps (TeslaMate, Prometheus, Homepage, Longhorn, z2m, Tautulli, …).

### How it works now
```
browser → changedetection.kalde.in → [gateway] → authentik-server (embedded outpost)
            → Authentik login if needed → reverse-proxies to changedetection.default.svc:5000
```

### Authentik side (`security` ns)
- `blueprints/changedetection.yaml` — **proxy provider** (`mode: proxy`, `external_host: https://changedetection.kalde.in`, `internal_host: http://changedetection.default.svc.cluster.local:5000`) + application. Plain **ConfigMap** (no client secret needed).
- `blueprints/proxy-outpost.yaml` — central registry assigning proxy providers to the **embedded outpost** (one `!Find` line per forward-auth app going forward).
- `referencegrant.yaml` — lets `default`-ns HTTPRoutes target the `authentik-server` Service.

### changedetection side (`default` ns)
- Removed the app's direct `route:` — no longer exposed on its own.
- New `httproute.yaml` sending `changedetection.kalde.in` → `authentik-server:80` (cross-ns, allowed by the grant).

### Behavior changes to know
- **Whole-site gating:** every request hits Authentik first (no per-app login button like the OIDC apps). Transparent once you're signed in to Authentik.
- **changedetection's own password** (if set) becomes redundant double-auth — recommend clearing it in changedetection Settings once this works.
- **Access control** is "any valid Authentik user" for now; can scope to a group/policy later.

### Validation
`kustomize build` passes on both overlays; only one HTTPRoute renders (→ outpost), ReferenceGrant + ConfigMaps wired. Branch is off `main` and independent of the Linkding PR (#395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)