### PR TITLE
feat(tautulli): gate behind Authentik proxy outpost (forward-auth)

### DIFF
--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -51,29 +51,11 @@ spec:
       app:
         ports:
           http:
-            port: &port 8181
+            port: 8181
 
-    route:
-      app:
-        annotations:
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/name: Tautulli
-          gethomepage.dev/description: Plex statistics
-          gethomepage.dev/group: Media
-          gethomepage.dev/icon: tautulli.png
-          gethomepage.dev/href: https://tautulli.kalde.in
-        hostnames: ["{{ .Release.Name }}.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: tautulli has no OIDC, so it is exposed only via the
+    # Authentik embedded proxy outpost. See ./httproute.yaml, which sends
+    # tautulli.kalde.in to authentik-server (the outpost) instead.
 
     persistence:
       config:

--- a/kubernetes/apps/media/tautulli/app/httproute.yaml
+++ b/kubernetes/apps/media/tautulli/app/httproute.yaml
@@ -1,0 +1,33 @@
+---
+# tautulli is fronted by the Authentik embedded proxy outpost: route the
+# public host to authentik-server (security ns), which authenticates and then
+# proxies to the tautulli Service internally. Cross-namespace backendRef is
+# permitted by the ReferenceGrant in the security namespace.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tautulli
+  namespace: media
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Tautulli
+    gethomepage.dev/description: Plex statistics
+    gethomepage.dev/group: Media
+    gethomepage.dev/icon: tautulli.png
+    gethomepage.dev/href: https://tautulli.kalde.in
+spec:
+  hostnames:
+    - tautulli.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/media/tautulli/app/kustomization.yaml
+++ b/kubernetes/apps/media/tautulli/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./config-pvc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -47,6 +47,33 @@ data:
           meta_description: Website change monitor
           policy_engine_mode: any
 
+      # ── tautulli ──────────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-tautulli
+        state: present
+        identifiers:
+          name: tautulli
+        attrs:
+          name: tautulli
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://tautulli.kalde.in
+          internal_host: http://tautulli.media.svc.cluster.local:8181
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-tautulli
+        state: present
+        identifiers:
+          slug: tautulli
+        attrs:
+          name: Tautulli
+          slug: tautulli
+          provider: !KeyOf provider-tautulli
+          meta_launch_url: https://tautulli.kalde.in
+          meta_description: Plex statistics
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -55,3 +82,4 @@ data:
         attrs:
           providers:
             - !KeyOf provider-changedetection
+            - !KeyOf provider-tautulli

--- a/kubernetes/apps/security/authentik/app/referencegrant.yaml
+++ b/kubernetes/apps/security/authentik/app/referencegrant.yaml
@@ -1,6 +1,6 @@
 ---
-# Allow HTTPRoutes in the default namespace (proxied apps) to send traffic to
-# the authentik-server Service, which runs the embedded proxy outpost.
+# Allow HTTPRoutes in app namespaces (proxied apps) to send traffic to the
+# authentik-server Service, which runs the embedded proxy outpost.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
@@ -11,6 +11,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: default
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: media
   to:
     - group: ""
       kind: Service


### PR DESCRIPTION
## Forward-auth app #2: Tautulli

Tautulli has its own login and no OIDC, so it's gated by the Authentik embedded proxy outpost — the same pattern as changedetection, now using the consolidated `forward-auth.yaml` from #397.

### Changes
- **`blueprints/forward-auth.yaml`** — add the tautulli proxy provider (`internal_host: http://tautulli.media.svc.cluster.local:8181`) + application, and a `!KeyOf provider-tautulli` line on the embedded outpost. Deterministic, no `!Find` race.
- **`referencegrant.yaml`** — extend the `from` list to the **`media`** namespace (tautulli lives there, not `default`), so its HTTPRoute can target `authentik-server`.
- **tautulli** (`media` ns) — drop the app-template `route:`; add a standalone `httproute.yaml` sending `tautulli.kalde.in` → `authentik-server:80`.

### Notes
- Nothing calls Tautulli's API internally (no Homepage widget), so gating the public host has no integration impact. (If a future integration needs the API, it should use the internal `tautulli.media.svc` Service, which bypasses the outpost.)
- Whole-site gating: Authentik login first, then Tautulli. Recommend disabling Tautulli's own login afterward to avoid double auth.

### Validation
`kustomize build` passes on both overlays; outpost now lists changedetection + tautulli; only one HTTPRoute (→ outpost) renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)