### PR TITLE
fix(forward-auth): name standalone routes <app>-auth to avoid Helm race

### DIFF
--- a/kubernetes/apps/default/changedetection/app/httproute.yaml
+++ b/kubernetes/apps/default/changedetection/app/httproute.yaml
@@ -7,7 +7,9 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: changedetection
+  # "-auth" suffix avoids colliding with the app-template route name
+  # ("changedetection") during migration — see tautulli httproute for details.
+  name: changedetection-auth
   namespace: default
   annotations:
     gethomepage.dev/enabled: "true"

--- a/kubernetes/apps/media/tautulli/app/httproute.yaml
+++ b/kubernetes/apps/media/tautulli/app/httproute.yaml
@@ -3,11 +3,14 @@
 # public host to authentik-server (security ns), which authenticates and then
 # proxies to the tautulli Service internally. Cross-namespace backendRef is
 # permitted by the ReferenceGrant in the security namespace.
+# Name is "<app>-auth", NOT "tautulli": the app-template route (now removed)
+# was named "tautulli", and a same-named standalone route races with the Helm
+# prune during migration (Flux creates it, Helm deletes the old one → 404).
 # yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: tautulli
+  name: tautulli-auth
   namespace: media
   annotations:
     gethomepage.dev/enabled: "true"


### PR DESCRIPTION
## Fix the recurring forward-auth 404 (HTTPRoute silently not created)

Both changedetection (#396) and tautulli (#398) 404'd after merge and needed a manual `flux reconcile` to create their HTTPRoute. Same root cause both times.

### Root cause
bjw-s **app-template names its route HTTPRoute after the release** (`tautulli`, `changedetection`, `miniflux`, … — bare release names, verified against live routes). The forward-auth migration removes that `route:` block and adds a standalone HTTPRoute with the **same name**. On reconcile:
- Helm upgrade prunes its old `tautulli` HTTPRoute, **and**
- Flux kustomize creates the new `tautulli` HTTPRoute

…race. The Helm prune deletes the freshly-created route → it's gone until a forced reconcile (by which point Helm has settled). Flux still reports `READY` because the route is in its inventory.

### Fix
Name the standalone route **`<app>-auth`** so it can't collide: Helm prunes `<app>`, Flux creates `<app>-auth`, no overlap. The hostname is unchanged (`tautulli.kalde.in`, `changedetection.kalde.in`).

- `tautulli` route → `tautulli-auth`
- `changedetection` route → `changedetection-auth`

This is now the convention for all remaining forward-auth apps, so they won't need a manual reconcile during migration.

Both apps are currently working (their routes are Flux-owned after the earlier forced reconciles); this rename is an in-place Flux operation (create new, prune old, same host) and is the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)