### PR TITLE
feat(sabnzbd): gate behind Authentik proxy outpost (forward-auth)

### DIFF
--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -73,27 +73,11 @@ spec:
           http:
             port: *port
 
-    route:
-      app:
-        annotations:
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/name: SABnzbd
-          gethomepage.dev/description: Usenet downloader
-          gethomepage.dev/group: Media
-          gethomepage.dev/icon: sabnzbd.png
-          gethomepage.dev/href: https://sabnzbd.kalde.in
-        hostnames: ["{{ .Release.Name }}.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: sabnzbd has no OIDC, so it is exposed only via the
+    # Authentik embedded proxy outpost. See ./httproute.yaml, which sends
+    # sabnzbd.kalde.in to authentik-server (the outpost) instead. The
+    # HOST_WHITELIST_ENTRIES above keep sabnzbd.kalde.in so sabnzbd accepts
+    # the proxied request.
 
     persistence:
       config:

--- a/kubernetes/apps/media/sabnzbd/app/httproute.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/httproute.yaml
@@ -1,0 +1,35 @@
+---
+# sabnzbd is fronted by the Authentik embedded proxy outpost: route the public
+# host to authentik-server (security ns), which authenticates and then proxies
+# to the sabnzbd Service internally. Cross-namespace backendRef is permitted by
+# the ReferenceGrant in the security namespace.
+# Name is "sabnzbd-auth", NOT "sabnzbd": a same-named standalone route races
+# with the Helm prune of the old app-template route during migration.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sabnzbd-auth
+  namespace: media
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: SABnzbd
+    gethomepage.dev/description: Usenet downloader
+    gethomepage.dev/group: Media
+    gethomepage.dev/icon: sabnzbd.png
+    gethomepage.dev/href: https://sabnzbd.kalde.in
+spec:
+  hostnames:
+    - sabnzbd.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/media/sabnzbd/app/kustomization.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./config-pvc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -74,6 +74,33 @@ data:
           meta_description: Plex statistics
           policy_engine_mode: any
 
+      # ── sabnzbd ───────────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-sabnzbd
+        state: present
+        identifiers:
+          name: sabnzbd
+        attrs:
+          name: sabnzbd
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://sabnzbd.kalde.in
+          internal_host: http://sabnzbd.media.svc.cluster.local
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-sabnzbd
+        state: present
+        identifiers:
+          slug: sabnzbd
+        attrs:
+          name: SABnzbd
+          slug: sabnzbd
+          provider: !KeyOf provider-sabnzbd
+          meta_launch_url: https://sabnzbd.kalde.in
+          meta_description: Usenet downloader
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -83,3 +110,4 @@ data:
           providers:
             - !KeyOf provider-changedetection
             - !KeyOf provider-tautulli
+            - !KeyOf provider-sabnzbd


### PR DESCRIPTION
## Forward-auth app #3: SABnzbd

Same hardened pattern as tautulli — add to `forward-auth.yaml`, `<app>-auth` route, ReferenceGrant already covers `media`.

### Changes
- **`blueprints/forward-auth.yaml`** — sabnzbd proxy provider (`internal_host: http://sabnzbd.media.svc.cluster.local`, port 80) + application + `!KeyOf provider-sabnzbd` on the outpost.
- **sabnzbd** (`media` ns) — drop the app-template `route:`; add standalone `httproute.yaml` named **`sabnzbd-auth`** → `authentik-server:80`. Kept `HOST_WHITELIST_ENTRIES` (it already lists `sabnzbd.kalde.in`, which sabnzbd verifies on the proxied request).

### Integrations unaffected
The *arr download clients reach sabnzbd via internal Service DNS + API key, which **bypasses the outpost** — confirmed nothing references `sabnzbd.kalde.in` in-repo. API access is independent of the UI login.

### Post-merge step (I'll do it, like tautulli)
sabnzbd has its own UI login (`username = clay`, `html_login = 1`). Behind the outpost that double-auths, so after merge I'll disable it in `sabnzbd.ini` (back up first) and restart. Its API key stays.

### Validation
`kustomize build` passes; outpost lists changedetection + tautulli + sabnzbd; single HTTPRoute (→ outpost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)