### PR TITLE
feat(prometheus): gate UI behind Authentik, exempt /federate

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -1,6 +1,9 @@
 ---
-# Internal-only HTTPRoute for Prometheus
-# Uses internal Gateway only - not exposed externally
+# Internal-only HTTPRoute for Prometheus.
+# Fronted by the Authentik embedded proxy outpost (authentik-server, security
+# ns): it gates the UI but exempts /federate (skip_path_regex in the proxy
+# provider) so the observability cluster's federation scrape keeps working.
+# Cross-namespace backendRef is permitted by the ReferenceGrant in security.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -14,5 +17,6 @@ spec:
     - prometheus.kalde.in
   rules:
     - backendRefs:
-        - name: kube-prometheus-stack-prometheus
-          port: 9090
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -101,6 +101,37 @@ data:
           meta_description: Usenet downloader
           policy_engine_mode: any
 
+      # ── prometheus ────────────────────────────────────────────────────
+      # skip_path_regex exempts /federate from auth so the observability
+      # cluster's federation scrape (GET /federate) keeps working; the UI is
+      # still gated. Internal-only (see httproute), like the rest of prometheus.
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-prometheus
+        state: present
+        identifiers:
+          name: prometheus
+        attrs:
+          name: prometheus
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://prometheus.kalde.in
+          internal_host: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+          internal_host_ssl_validation: false
+          skip_path_regex: ^/federate
+      - model: authentik_core.application
+        id: app-prometheus
+        state: present
+        identifiers:
+          slug: prometheus
+        attrs:
+          name: Prometheus
+          slug: prometheus
+          provider: !KeyOf provider-prometheus
+          meta_launch_url: https://prometheus.kalde.in
+          meta_description: Metrics
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -111,3 +142,4 @@ data:
             - !KeyOf provider-changedetection
             - !KeyOf provider-tautulli
             - !KeyOf provider-sabnzbd
+            - !KeyOf provider-prometheus

--- a/kubernetes/apps/security/authentik/app/referencegrant.yaml
+++ b/kubernetes/apps/security/authentik/app/referencegrant.yaml
@@ -14,6 +14,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: media
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: observability
   to:
     - group: ""
       kind: Service


### PR DESCRIPTION
## Forward-auth for Prometheus — without breaking cross-cluster federation

The `home-ops-observability` cluster federates from this Prometheus:
```yaml
job_name: federate-main-cluster
metrics_path: /federate
params: { 'match[]': ['{job=~".+"}'] }
scheme: https
targets: [prometheus.kalde.in]
```
No auth — it relies on Prometheus being open. Gating the whole host would 302 the scraper to login and silently kill federation.

### Fix
Gate the **UI**, exempt the **scrape path**:
- **`forward-auth.yaml`** — prometheus proxy provider with **`skip_path_regex: ^/federate`**. `/federate` bypasses auth (proxied straight through, exactly as today); `/graph`, `/alerts`, the API, etc. require Authentik login. No change on the observability cluster, no security regression.
- **`referencegrant.yaml`** — add the `observability` namespace.
- **prometheus `httproute.yaml`** — repoint the backend to `authentik-server`. This route was already a standalone Flux-managed HTTPRoute (not an app-template route), so it's an in-place backend swap — **no Helm-prune race, no `-auth` rename**. Stays **internal-only**.

### Validation
`kustomize build` passes; outpost lists changedetection + tautulli + sabnzbd + prometheus; route is internal-only → authentik-server; `skip_path_regex` present.

### Verify after merge
- `curl -k https://prometheus.kalde.in/federate?match[]={job=~".+"}` (from a LAN host) returns metrics, not a login redirect.
- The UI (`/graph`) redirects to Authentik.
- Federation metrics keep flowing on the observability cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)