### PR TITLE
feat(homepage): gate behind Authentik proxy outpost (forward-auth)

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -30,8 +30,11 @@ spec:
               repository: ghcr.io/gethomepage/homepage
               tag: v1.13.2
             env:
-              # Homepage v1 rejects requests whose Host header is not allow-listed
-              HOMEPAGE_ALLOWED_HOSTS: homepage.kalde.in
+              # Homepage v1 rejects requests whose Host header is not allow-listed.
+              # Include the internal Service name too: behind the Authentik
+              # outpost the upstream Host header may be the internal target
+              # rather than homepage.kalde.in.
+              HOMEPAGE_ALLOWED_HOSTS: "homepage.kalde.in,homepage.default.svc.cluster.local:3000,homepage.default.svc.cluster.local"
             envFrom:
               # Service-widget API keys -> {{HOMEPAGE_VAR_*}} substitution
               - secretRef:
@@ -50,17 +53,9 @@ spec:
           http:
             port: &port 3000
 
-    route:
-      app:
-        hostnames: ["{{ .Release.Name }}.kalde.in"]
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: homepage is exposed only via the Authentik embedded
+    # proxy outpost. See ./httproute.yaml, which sends homepage.kalde.in to
+    # authentik-server (the outpost). Internal-only, as before.
 
     persistence:
       # Mount each config file individually via subPath so /app/config itself

--- a/kubernetes/apps/default/homepage/app/httproute.yaml
+++ b/kubernetes/apps/default/homepage/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+# homepage is fronted by the Authentik embedded proxy outpost: route the public
+# host to authentik-server (security ns), which authenticates and then proxies
+# to the homepage Service internally. Internal-only, as before. Cross-namespace
+# backendRef is permitted by the ReferenceGrant in the security namespace.
+# Name is "homepage-auth", NOT "homepage", to avoid colliding with the
+# app-template route name during migration (Helm prune vs Flux create race).
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homepage-auth
+  namespace: default
+spec:
+  hostnames:
+    - homepage.kalde.in
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/homepage/app/kustomization.yaml
+++ b/kubernetes/apps/default/homepage/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -132,6 +132,33 @@ data:
           meta_description: Metrics
           policy_engine_mode: any
 
+      # ── homepage ──────────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-homepage
+        state: present
+        identifiers:
+          name: homepage
+        attrs:
+          name: homepage
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://homepage.kalde.in
+          internal_host: http://homepage.default.svc.cluster.local:3000
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-homepage
+        state: present
+        identifiers:
+          slug: homepage
+        attrs:
+          name: Homepage
+          slug: homepage
+          provider: !KeyOf provider-homepage
+          meta_launch_url: https://homepage.kalde.in
+          meta_description: Dashboard
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -143,3 +170,4 @@ data:
             - !KeyOf provider-tautulli
             - !KeyOf provider-sabnzbd
             - !KeyOf provider-prometheus
+            - !KeyOf provider-homepage


### PR DESCRIPTION
## Forward-auth app #6: Homepage

Clean one — Homepage has **no built-in auth**, so no disable step, and it's a pure UI (no machine endpoint), so a single PR is fine.

### Changes
- **`forward-auth.yaml`** — homepage proxy provider (`internal_host: http://homepage.default.svc.cluster.local:3000`) + application + `!KeyOf` on the outpost (now 5 forward-auth apps).
- **homepage** (`default` ns) — drop the app-template `route:`; add standalone `homepage-auth` HTTPRoute → `authentik-server`, **internal-only** as before.
- **`HOMEPAGE_ALLOWED_HOSTS`** — broadened to include the internal Service name (with and without port). Homepage v1 rejects non-allow-listed `Host` headers; if the outpost forwards the internal Host rather than `homepage.kalde.in`, this prevents a 403.

### Unaffected
Homepage's service-widget API calls are **outbound** to internal Service DNS (e.g. `radarr.media.svc`), which bypasses the outpost. ReferenceGrant already covers `default`.

### Validation
`kustomize build` passes; `homepage-auth` route is internal-only → authentik-server; outpost lists 5 providers.

### After merge
Pure UI, so worst case is a brief cutover blip (no machine endpoint to break). I'll confirm the outpost picks up homepage and `homepage.kalde.in` → Authentik login → dashboard. If Homepage 403s on the Host header, I'll check which Host the outpost forwards and tighten `HOMEPAGE_ALLOWED_HOSTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)