### PR TITLE
fix(homepage): restore status for forward-auth apps

### DIFF
--- a/kubernetes/apps/default/changedetection/app/httproute.yaml
+++ b/kubernetes/apps/default/changedetection/app/httproute.yaml
@@ -13,6 +13,10 @@ metadata:
   namespace: default
   annotations:
     gethomepage.dev/enabled: "true"
+    # Status detection: the route is named changedetection-auth, but the app
+    # pods are labelled app.kubernetes.io/name=changedetection. Without this,
+    # Homepage derives the selector from the route name and finds no pods.
+    gethomepage.dev/app: changedetection
     gethomepage.dev/name: Changedetection
     gethomepage.dev/description: Website change monitor
     gethomepage.dev/group: Infrastructure

--- a/kubernetes/apps/media/sabnzbd/app/httproute.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/httproute.yaml
@@ -13,6 +13,8 @@ metadata:
   namespace: media
   annotations:
     gethomepage.dev/enabled: "true"
+    # Route is sabnzbd-auth; point status detection at the real app pods.
+    gethomepage.dev/app: sabnzbd
     gethomepage.dev/name: SABnzbd
     gethomepage.dev/description: Usenet downloader
     gethomepage.dev/group: Media

--- a/kubernetes/apps/media/tautulli/app/httproute.yaml
+++ b/kubernetes/apps/media/tautulli/app/httproute.yaml
@@ -14,6 +14,8 @@ metadata:
   namespace: media
   annotations:
     gethomepage.dev/enabled: "true"
+    # Route is tautulli-auth; point status detection at the real app pods.
+    gethomepage.dev/app: tautulli
     gethomepage.dev/name: Tautulli
     gethomepage.dev/description: Plex statistics
     gethomepage.dev/group: Media


### PR DESCRIPTION
## Fix: Homepage lost status for the forward-auth apps

After the forward-auth migrations, Homepage stopped showing status for changedetection, tautulli, and sabnzbd.

### Root cause (from Homepage logs)
```
<kubernetesStatusService> no pods found with namespace=media and labelSelector=app.kubernetes.io/name=tautulli-auth
```
Homepage's status check defaults `gethomepage.dev/app` to the **HTTPRoute name** and builds the selector `app.kubernetes.io/name=<route-name>`. The forward-auth migration renamed the routes to `<app>-auth` (to avoid the Helm-prune race), so Homepage searched for `tautulli-auth`/`sabnzbd-auth`/`changedetection-auth` pods — which don't exist.

### Fix
Add `gethomepage.dev/app: <real-app>` to each `-auth` route, pointing status detection back at the real app pods (labels confirmed: `app.kubernetes.io/name=<app>` matches running pods).

OIDC apps (Miniflux, Linkding) are unaffected — their routes kept their original names.

### Convention going forward
Any forward-auth route renamed to `<app>-auth` must also set `gethomepage.dev/app: <app>` (recorded in notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)