### PR TITLE
feat(authentik): auto-reload worker on blueprint changes

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -70,3 +70,10 @@ spec:
         enabled: false
     worker:
       replicas: 1
+      # Restart the worker when any mounted blueprint ConfigMap/Secret changes,
+      # so blueprints re-apply immediately instead of waiting for Authentik's
+      # discovery interval. Only the worker (it applies blueprints); the
+      # server's embedded outpost picks up provider changes via API polling, so
+      # gating/login stay up.
+      deploymentAnnotations:
+        reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Stop the manual blueprint nudge

Every forward-auth app (sabnzbd, prometheus, homepage) needed a manual nudge after merge because the worker only re-applies blueprints on Authentik's discovery interval — so the provider/outpost attachment lagged. With Prometheus it was worse: the route flipped to the outpost before the provider existed, 404'ing federation until I intervened.

### Change
Add `reloader.stakater.com/auto: "true"` to the Authentik **worker** `deploymentAnnotations` (via `worker.deploymentAnnotations`). When a mounted blueprint ConfigMap/Secret changes, [Reloader](https://github.com/stakater/Reloader) restarts the worker, which re-applies blueprints on startup — immediately, no nudge.

### Why worker-only
The worker applies blueprints. The server runs the embedded outpost, which picks up provider changes via API polling — so it needs no restart, and **login/gating stay up**. Restarting only the worker avoids any auth downtime.

### Confirmed
- Reloader is already running in `kube-system`.
- The blueprint ConfigMap (`authentik-blueprint-forward-auth`) and secrets (`authentik-blueprint-miniflux/linkding`) are mounted as worker volumes, so Reloader watches them.
- ESO re-syncs don't cause spurious restarts (Reloader hashes data, not resourceVersion).

### Net effect
Future forward-auth merges should "just work" — provider created + outpost attached within a worker restart, no manual `flux reconcile` / blueprint apply. The ordering caveat for machine endpoints still stands, but the window shrinks dramatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)