### PR TITLE
feat(longhorn): gate UI behind Authentik (internal-only forward-auth)

### DIFF
--- a/kubernetes/apps/longhorn/longhorn-system/app/httproute.yaml
+++ b/kubernetes/apps/longhorn/longhorn-system/app/httproute.yaml
@@ -1,6 +1,9 @@
 ---
-# Internal-only: the Longhorn admin UI has no built-in auth, so it is not
-# exposed on the external gateway. Reachable on the LAN only.
+# Internal-only AND gated: the Longhorn admin UI has no built-in auth, so it is
+# kept off the external gateway and fronted by the Authentik embedded proxy
+# outpost (authentik-server, security ns). LAN access still requires an
+# Authentik login. Cross-namespace backendRef allowed by the ReferenceGrant in
+# the security namespace.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -23,7 +26,7 @@ spec:
       backendRefs:
         - group: ""
           kind: Service
-          name: longhorn-frontend
-          namespace: longhorn-system
+          name: authentik-server
+          namespace: security
           port: 80
           weight: 1

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -159,6 +159,33 @@ data:
           meta_description: Dashboard
           policy_engine_mode: any
 
+      # ── longhorn (internal-only; no built-in auth) ──────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-longhorn
+        state: present
+        identifiers:
+          name: longhorn
+        attrs:
+          name: longhorn
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://longhorn.kalde.in
+          internal_host: http://longhorn-frontend.longhorn-system.svc.cluster.local
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-longhorn
+        state: present
+        identifiers:
+          slug: longhorn
+        attrs:
+          name: Longhorn
+          slug: longhorn
+          provider: !KeyOf provider-longhorn
+          meta_launch_url: https://longhorn.kalde.in
+          meta_description: Storage
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -171,3 +198,4 @@ data:
             - !KeyOf provider-sabnzbd
             - !KeyOf provider-prometheus
             - !KeyOf provider-homepage
+            - !KeyOf provider-longhorn

--- a/kubernetes/apps/security/authentik/app/referencegrant.yaml
+++ b/kubernetes/apps/security/authentik/app/referencegrant.yaml
@@ -17,6 +17,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: observability
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: longhorn-system
   to:
     - group: ""
       kind: Service


### PR DESCRIPTION
## Add auth to the Longhorn UI

Longhorn has no built-in auth and is a destructive storage admin UI, so it's now behind the Authentik embedded proxy outpost. **Kept internal-only** (per the #405 decision) — LAN access now also requires an Authentik login; still not externally exposed.

### Changes
- **`forward-auth.yaml`** — longhorn proxy provider (`internal_host: http://longhorn-frontend.longhorn-system.svc.cluster.local`) + application + `!KeyOf` on the outpost (now 6 forward-auth apps).
- **`referencegrant.yaml`** — add the `longhorn-system` namespace.
- **longhorn `httproute.yaml`** — repoint backend `longhorn-frontend` → `authentik-server` **in place** (standalone Flux route, like prometheus — no Helm race, no `-auth` rename). Still attached to the **internal** gateway only.

### No disable-login step
Longhorn has no built-in auth, so nothing to turn off.

### First run with auto-reload
This is the first forward-auth merge since #404 (worker reloader). On merge the worker should restart and apply the blueprint automatically — no manual nudge. I'll verify the provider attaches and `longhorn.kalde.in` gates correctly on the LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)