### PR TITLE
feat(zigbee2mqtt): gate behind Authentik (internal-only forward-auth)

### DIFF
--- a/kubernetes/apps/default/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/helmrelease.yaml
@@ -83,17 +83,9 @@ spec:
           http:
             port: *port
 
-    route:
-      app:
-        hostnames: ["z2m.kalde.in"]
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: zigbee2mqtt is exposed only via the Authentik embedded
+    # proxy outpost. See ./httproute.yaml, which sends z2m.kalde.in to
+    # authentik-server (the outpost). Internal-only, as before.
 
     persistence:
       data:

--- a/kubernetes/apps/default/zigbee2mqtt/app/httproute.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+# zigbee2mqtt is fronted by the Authentik embedded proxy outpost: route the
+# public host to authentik-server (security ns), which authenticates and then
+# proxies (including the frontend websocket) to the zigbee2mqtt Service.
+# Internal-only. Cross-namespace backendRef allowed by the ReferenceGrant in
+# the security namespace. Name is "zigbee2mqtt-auth", NOT "zigbee2mqtt", to
+# avoid colliding with the app-template route name during migration.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zigbee2mqtt-auth
+  namespace: default
+spec:
+  hostnames:
+    - z2m.kalde.in
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/zigbee2mqtt/app/kustomization.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./externalsecret.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -186,6 +186,33 @@ data:
           meta_description: Storage
           policy_engine_mode: any
 
+      # ── zigbee2mqtt (internal-only; no built-in auth; websocket UI) ─────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-zigbee2mqtt
+        state: present
+        identifiers:
+          name: zigbee2mqtt
+        attrs:
+          name: zigbee2mqtt
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://z2m.kalde.in
+          internal_host: http://zigbee2mqtt.default.svc.cluster.local:8080
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-zigbee2mqtt
+        state: present
+        identifiers:
+          slug: zigbee2mqtt
+        attrs:
+          name: Zigbee2MQTT
+          slug: zigbee2mqtt
+          provider: !KeyOf provider-zigbee2mqtt
+          meta_launch_url: https://z2m.kalde.in
+          meta_description: Zigbee
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -199,3 +226,4 @@ data:
             - !KeyOf provider-prometheus
             - !KeyOf provider-homepage
             - !KeyOf provider-longhorn
+            - !KeyOf provider-zigbee2mqtt


### PR DESCRIPTION
## Forward-auth app #7: Zigbee2MQTT

Clean one — internal-only, `default` ns, and **no frontend `auth_token`** set, so nothing to disable.

### Changes
- **`forward-auth.yaml`** — zigbee2mqtt proxy provider (`internal_host: http://zigbee2mqtt.default.svc.cluster.local:8080`) + application + `!KeyOf` on the outpost (now 7 forward-auth apps).
- **z2m** (`default` ns) — drop the app-template `route:`; add standalone `zigbee2mqtt-auth` HTTPRoute → `authentik-server`, **internal** gateway.

### Note: websocket
z2m's frontend uses a websocket for live device updates. Authentik's proxy mode proxies websockets, so it should work — I'll verify after merge (UI loads *and* live updates flow).

### Auto-applies on merge
Worker auto-reload (#404) is active, so the blueprint applies on its own (~90s after merge). I'll verify the provider attaches and `z2m.kalde.in` gates + the WS works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)