### PR TITLE
feat(teslamate-grafana): sign in with Authentik (OIDC)

### DIFF
--- a/kubernetes/apps/default/teslamate/app/externalsecret.yaml
+++ b/kubernetes/apps/default/teslamate/app/externalsecret.yaml
@@ -22,6 +22,11 @@ spec:
         DATABASE_PASS: "{{ .DATABASE_PASS }}"
         ENCRYPTION_KEY: "{{ .ENCRYPTION_KEY }}"
 
+        # Grafana SSO (Authentik generic OAuth) — consumed by teslamate-grafana,
+        # which does envFrom this same secret. Harmless extra keys for teslamate.
+        GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+
         # init database
         INIT_POSTGRES_DBNAME: "{{ .DATABASE_NAME }}"
         INIT_POSTGRES_HOST: postgres17-rw.database.svc.cluster.local

--- a/kubernetes/apps/default/teslamate/grafana/helmrelease.yaml
+++ b/kubernetes/apps/default/teslamate/grafana/helmrelease.yaml
@@ -37,6 +37,21 @@ spec:
               DATABASE_HOST: postgres17-rw.database.svc.cluster.local
               GF_METRICS_ENABLED: "true"
               GF_METRICS_DISABLE_TOTAL_STATS: "true"
+              # Required for OAuth redirects to resolve to the public URL
+              GF_SERVER_ROOT_URL: https://tesla-grafana.kalde.in
+              # SSO via Authentik (client id/secret come from teslamate-secret).
+              # Local admin login is kept as break-glass (form not disabled).
+              GF_AUTH_GENERIC_OAUTH_ENABLED: "true"
+              GF_AUTH_GENERIC_OAUTH_NAME: Authentik
+              GF_AUTH_GENERIC_OAUTH_SCOPES: "openid email profile"
+              GF_AUTH_GENERIC_OAUTH_AUTH_URL: https://auth.kalde.in/application/o/authorize/
+              GF_AUTH_GENERIC_OAUTH_TOKEN_URL: https://auth.kalde.in/application/o/token/
+              GF_AUTH_GENERIC_OAUTH_API_URL: https://auth.kalde.in/application/o/userinfo/
+              GF_AUTH_GENERIC_OAUTH_USE_PKCE: "true"
+              GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP: "true"
+              # Single-user homelab: grant Admin to anyone who logs in via
+              # Authentik. Tighten to a group mapping if more users are added.
+              GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "'Admin'"
             envFrom:
               - secretRef:
                   name: teslamate-secret

--- a/kubernetes/apps/security/authentik/app/blueprints/teslamate-grafana.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/teslamate-grafana.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-teslamate-grafana
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-teslamate-grafana
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        teslamate-grafana.yaml: |
+          version: 1
+          metadata:
+            name: teslamate-grafana
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-teslamate-grafana
+              state: present
+              identifiers:
+                name: teslamate-grafana
+              attrs:
+                name: teslamate-grafana
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                grant_types:
+                  - authorization_code
+                  - refresh_token
+                redirect_uris:
+                  - url: https://tesla-grafana.kalde.in/login/generic_oauth
+                    matching_mode: strict
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-teslamate-grafana
+              state: present
+              identifiers:
+                slug: teslamate-grafana
+              attrs:
+                name: TeslaMate Grafana
+                slug: teslamate-grafana
+                provider: !KeyOf provider-teslamate-grafana
+                meta_launch_url: https://tesla-grafana.kalde.in
+                meta_description: Tesla dashboards
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: teslamate
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -53,6 +53,7 @@ spec:
       secrets:
         - authentik-blueprint-miniflux
         - authentik-blueprint-linkding
+        - authentik-blueprint-teslamate-grafana
       configMaps:
         - authentik-blueprint-forward-auth
     server:

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   # per-app SSO blueprints (provider + application definitions)
   - ./blueprints/miniflux.yaml
   - ./blueprints/linkding.yaml
+  - ./blueprints/teslamate-grafana.yaml
   # forward-auth (proxy outpost) apps — all in one deterministic blueprint
   - ./blueprints/forward-auth.yaml


### PR DESCRIPTION
## OIDC for Grafana (`tesla-grafana.kalde.in`)

This is the **only** Grafana in this cluster — the TeslaMate one. (The main kube-prometheus-stack Grafana is `enabled: false` here; cluster metrics live in the separate observability cluster's Grafana.)

### Changes
- **Authentik** — `blueprints/teslamate-grafana.yaml`: OAuth2 provider + application (slug `teslamate-grafana`, redirect `https://tesla-grafana.kalde.in/login/generic_oauth`, `grant_types` set), delivered as an ESO Secret.
- **Grafana** — `GF_AUTH_GENERIC_OAUTH_*` (generic OAuth against Authentik) + `GF_SERVER_ROOT_URL`. Client id/secret added to the existing `teslamate-secret` externalsecret (Grafana already `envFrom`s it).

### Requires (before merge)
Add two fields to the existing **`teslamate`** 1Password item:
- `OAUTH_CLIENT_ID`
- `OAUTH_CLIENT_SECRET`

### Behavior
- Login page shows a **"Sign in with Authentik"** button alongside the normal form (local admin kept as **break-glass** — not disabled).
- **Single-user:** the OIDC user is granted **Admin** (`ROLE_ATTRIBUTE_PATH: 'Admin'`). If you add more Authentik users, switch to a group-based mapping.
- **Dashboards unaffected** — Grafana dashboards are org-scoped, not per-user, so all TeslaMate dashboards remain.

### After merge
Worker auto-reload applies the blueprint. I'll verify the Authentik button works and lands you in Grafana as Admin with the TeslaMate dashboards intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)