### PR TITLE
feat(authentik): nightly database backup

### DIFF
--- a/kubernetes/apps/security/authentik/backup/externalsecret.yaml
+++ b/kubernetes/apps/security/authentik/backup/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-db-backup
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-db-backup-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        DB_HOST: postgres17-rw.database.svc.cluster.local
+        DB_USER: authentik
+        DB_PASS: "{{ .POSTGRES_PASS }}"
+  dataFrom:
+    - extract:
+        key: authentik
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/backup/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/backup/helmrelease.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik-db-backup
+  namespace: security
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: authentik-db-backup
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      authentik-db-backup:
+        type: cronjob
+        cronjob:
+          concurrencyPolicy: Forbid
+          schedule: "@daily"
+        pod:
+          restartPolicy: OnFailure
+        containers:
+          app:
+            image:
+              repository: casmith/pgsqldump
+              tag: v0.2.0
+              pullPolicy: IfNotPresent
+            env:
+              DB_NAME: authentik
+              FLAGS: "-Fc"
+            envFrom:
+              - secretRef:
+                  name: authentik-db-backup-secret
+
+    persistence:
+      backup:
+        enabled: true
+        type: nfs
+        server: 192.168.10.3
+        path: /volume1/cluster/db-backup/authentik
+        globalMounts:
+          - path: /pgsqldump

--- a/kubernetes/apps/security/authentik/backup/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/backup/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/security/authentik/backup/ocirepository.yaml
+++ b/kubernetes/apps/security/authentik/backup/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: authentik-db-backup
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/security/authentik/ks.yaml
+++ b/kubernetes/apps/security/authentik/ks.yaml
@@ -19,3 +19,23 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-authentik-backup
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-external-secrets-stores
+  path: ./kubernetes/apps/security/authentik/backup
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Back up the Authentik database

Authentik's DB (on the shared `postgres17` cluster) was the one app **not** covered by the nightly `pgsqldump` backups — important now that it's the SSO identity store gating everything. This adds it using the exact same per-app pattern as teslamate/miniflux/etc.

### Changes
- **`authentik/backup/`** — `casmith/pgsqldump:v0.2.0` CronJob, `@daily`, `-Fc` (custom format), dumping the `authentik` db to NFS `/volume1/cluster/db-backup/authentik`. Creds (`DB_USER: authentik`, `DB_PASS`) come from the **existing** `authentik` 1Password item (`POSTGRES_PASS`) — no new secrets needed.
- **`ks.yaml`** — second Flux Kustomization `cluster-apps-authentik-backup` (same multi-Kustomization style as teslamate).

### ⚠️ One manual step
Create the target directory on the NAS first, or the CronJob pod will fail to mount the NFS:
```
/volume1/cluster/db-backup/authentik   (on 192.168.10.3)
```

### After merge
I'll trigger the CronJob once (`kubectl create job --from=cronjob/...`) to confirm it dumps successfully and a backup file lands on the NAS, rather than wait for the nightly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)