### PR TITLE
feat(forward-auth): gate teslamate, kapowarr, consolewiki

### DIFF
--- a/kubernetes/apps/default/consolewiki/app/helmrelease.yaml
+++ b/kubernetes/apps/default/consolewiki/app/helmrelease.yaml
@@ -45,20 +45,8 @@ spec:
         ports:
           http:
             port: &port 80
-    route:
-      app:
-        hostnames: ["consolewiki.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: exposed only via the Authentik proxy outpost.
+    # See ./httproute.yaml.
     persistence:
       config:
         existingClaim: consolewiki-data-v1

--- a/kubernetes/apps/default/consolewiki/app/httproute.yaml
+++ b/kubernetes/apps/default/consolewiki/app/httproute.yaml
@@ -1,0 +1,23 @@
+---
+# consolewiki fronted by the Authentik embedded proxy outpost.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: consolewiki-auth
+  namespace: default
+spec:
+  hostnames:
+    - consolewiki.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/consolewiki/app/kustomization.yaml
+++ b/kubernetes/apps/default/consolewiki/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./config-pvc.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/kapowarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/kapowarr/app/helmrelease.yaml
@@ -46,20 +46,8 @@ spec:
           http:
             port: &port 5656
 
-    route:
-      app:
-        hostnames: ["{{ .Release.Name }}.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: exposed only via the Authentik proxy outpost.
+    # See ./httproute.yaml.
 
     persistence:
       db:

--- a/kubernetes/apps/default/kapowarr/app/httproute.yaml
+++ b/kubernetes/apps/default/kapowarr/app/httproute.yaml
@@ -1,0 +1,23 @@
+---
+# kapowarr fronted by the Authentik embedded proxy outpost.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kapowarr-auth
+  namespace: default
+spec:
+  hostnames:
+    - kapowarr.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/kapowarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/kapowarr/app/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: default
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/default/teslamate/app/helmrelease.yaml
@@ -60,17 +60,5 @@ spec:
           http:
             port: &port 4000
 
-    route:
-      app:
-        hostnames: ["tesla.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: teslamate has no built-in auth, so it is exposed only via
+    # the Authentik embedded proxy outpost. See ./httproute.yaml.

--- a/kubernetes/apps/default/teslamate/app/httproute.yaml
+++ b/kubernetes/apps/default/teslamate/app/httproute.yaml
@@ -1,0 +1,24 @@
+---
+# teslamate (no built-in auth) fronted by the Authentik embedded proxy outpost.
+# Name is "teslamate-auth" to avoid colliding with the app-template route name.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: teslamate-auth
+  namespace: default
+spec:
+  hostnames:
+    - tesla.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/teslamate/app/kustomization.yaml
+++ b/kubernetes/apps/default/teslamate/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -213,6 +213,87 @@ data:
           meta_description: Zigbee
           policy_engine_mode: any
 
+      # ── teslamate (no built-in auth; exposes car location/driving data) ──
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-teslamate
+        state: present
+        identifiers:
+          name: teslamate
+        attrs:
+          name: teslamate
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://tesla.kalde.in
+          internal_host: http://teslamate.default.svc.cluster.local:4000
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-teslamate
+        state: present
+        identifiers:
+          slug: teslamate
+        attrs:
+          name: TeslaMate
+          slug: teslamate
+          provider: !KeyOf provider-teslamate
+          meta_launch_url: https://tesla.kalde.in
+          meta_description: Tesla logger
+          policy_engine_mode: any
+
+      # ── kapowarr ─────────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-kapowarr
+        state: present
+        identifiers:
+          name: kapowarr
+        attrs:
+          name: kapowarr
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://kapowarr.kalde.in
+          internal_host: http://kapowarr.default.svc.cluster.local:5656
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-kapowarr
+        state: present
+        identifiers:
+          slug: kapowarr
+        attrs:
+          name: Kapowarr
+          slug: kapowarr
+          provider: !KeyOf provider-kapowarr
+          meta_launch_url: https://kapowarr.kalde.in
+          meta_description: Comics
+          policy_engine_mode: any
+
+      # ── consolewiki ──────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-consolewiki
+        state: present
+        identifiers:
+          name: consolewiki
+        attrs:
+          name: consolewiki
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://consolewiki.kalde.in
+          internal_host: http://consolewiki.default.svc.cluster.local:80
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-consolewiki
+        state: present
+        identifiers:
+          slug: consolewiki
+        attrs:
+          name: Console Wiki
+          slug: consolewiki
+          provider: !KeyOf provider-consolewiki
+          meta_launch_url: https://consolewiki.kalde.in
+          meta_description: Wiki
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -227,3 +308,6 @@ data:
             - !KeyOf provider-homepage
             - !KeyOf provider-longhorn
             - !KeyOf provider-zigbee2mqtt
+            - !KeyOf provider-teslamate
+            - !KeyOf provider-kapowarr
+            - !KeyOf provider-consolewiki


### PR DESCRIPTION
## Forward-auth batch: TeslaMate, Kapowarr, Console Wiki

Three no-/optional-auth apps onto the Authentik outpost (now 10 forward-auth apps total).

### TeslaMate — the point is split-horizon, not "it was open"
`tesla.kalde.in` was already guarded **externally** by Cloudflare Access (OIDC). What it lacked was auth on the **internal/LAN path** (Cloudflare Access doesn't cover that), and it used a separate auth system from the rest. Fronting it with the Authentik outpost covers **both** paths and unifies on Authentik — the original split-horizon goal. Cloudflare Access for this host can then be retired so it isn't double-auth externally.

### Changes (each app)
- **`forward-auth.yaml`** — proxy provider + application + `!KeyOf` on the outpost.
  - teslamate → `http://teslamate.default.svc:4000`
  - kapowarr → `http://kapowarr.default.svc:5656`
  - consolewiki → `http://consolewiki.default.svc:80`
- App-template `route:` replaced by a standalone `<app>-auth` HTTPRoute → `authentik-server` (same external+internal gateways).

### Post-merge notes
- **TeslaMate:** no built-in app auth — nothing to disable. Consider retiring the Cloudflare Access policy for `tesla.kalde.in`.
- **Kapowarr / Console Wiki:** optional built-in passwords; if set, I'll clear them post-merge (like Tautulli) so Authentik is the single login.
- Shared `forward-auth` ConfigMap change → worker auto-reload applies it (~90s).

### Validation
`kustomize build` passes on all four overlays; outpost lists 10 providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)