### PR TITLE
feat(otterwiki): external auth via Authentik PROXY_HEADER

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -267,7 +267,38 @@ data:
           meta_description: Comics
           policy_engine_mode: any
 
-      # ── consolewiki ──────────────────────────────────────────────────
+      # ── consolewiki / OtterWiki (multi-user; PROXY_HEADER auth) ─────────
+      # OtterWiki has no OIDC; it reads identity from reverse-proxy headers.
+      # The outpost injects x-otterwiki-name/email/permissions via the scope
+      # mapping below so OtterWiki stays multi-user but sourced from Authentik.
+      - model: authentik_core.group
+        id: group-otterwiki-admins
+        state: present
+        identifiers:
+          name: otterwiki-admins
+        attrs:
+          name: otterwiki-admins
+      - model: authentik_providers_oauth2.scopemapping
+        id: mapping-otterwiki-headers
+        state: present
+        identifiers:
+          name: otterwiki-headers
+        attrs:
+          name: otterwiki-headers
+          scope_name: otterwiki
+          description: "Inject x-otterwiki-* headers for OtterWiki PROXY_HEADER auth"
+          expression: |
+            return {
+                "ak_proxy": {
+                    "user_attributes": {
+                        "additionalHeaders": {
+                            "x-otterwiki-name": request.user.name,
+                            "x-otterwiki-email": request.user.email,
+                            "x-otterwiki-permissions": "READ,WRITE,UPLOAD,ADMIN" if ak_is_group_member(request.user, name="otterwiki-admins") else "READ,WRITE,UPLOAD",
+                        }
+                    }
+                }
+            }
       - model: authentik_providers_proxy.proxyprovider
         id: provider-consolewiki
         state: present
@@ -281,13 +312,15 @@ data:
           external_host: https://consolewiki.kalde.in
           internal_host: http://consolewiki.default.svc.cluster.local:80
           internal_host_ssl_validation: false
+          property_mappings:
+            - !KeyOf mapping-otterwiki-headers
       - model: authentik_core.application
         id: app-consolewiki
         state: present
         identifiers:
           slug: consolewiki
         attrs:
-          name: Console Wiki
+          name: OtterWiki
           slug: consolewiki
           provider: !KeyOf provider-consolewiki
           meta_launch_url: https://consolewiki.kalde.in


### PR DESCRIPTION
## Fix: OtterWiki external auth (it's multi-user, not single-user)

#410 put OtterWiki (`consolewiki`, `redimp/otterwiki`) behind the outpost as a plain gated app — but it's **multi-user and shared**, so that locks out anyone without an Authentik account and double-logins. OtterWiki has **no OIDC**; its external-auth mechanism is **`AUTH_METHOD=PROXY_HEADER`** (reads identity from headers). ([docs](https://otterwiki.com/Configuration))

### This PR (Authentik side)
- **Scope mapping `otterwiki-headers`** on the consolewiki proxy provider that injects:
  - `x-otterwiki-name` = user's name
  - `x-otterwiki-email` = user's email
  - `x-otterwiki-permissions` = `READ,WRITE,UPLOAD,ADMIN` for the **`otterwiki-admins`** group, else `READ,WRITE,UPLOAD`
- **`otterwiki-admins` group** for the admin mapping.

So OtterWiki stays multi-user, but every identity comes from Authentik.

### Two follow-ups (after merge — I'll do/guide)
1. **OtterWiki:** set `AUTH_METHOD = 'PROXY_HEADER'` in `/app-data/settings.cfg` (config lives in the PVC). I'll do this once the headers are flowing and verify.
2. **You:** give each shared person an **Authentik account with the same email** as their OtterWiki account (so they map to their existing wiki user, not a new one), and add yourself to the `otterwiki-admins` group.

### Note
Permissions model is a sensible default (group→admin, everyone-else→editor). Easy to change — e.g. read-only for shared users — just say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)