### PR TITLE
feat(authentik): declarative per-app access control

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -1,0 +1,85 @@
+---
+# Declarative per-application access control.
+#
+# Authentik apps are open to ALL logged-in users until a group is bound to
+# them. This binds each app to a group so only intended members can reach it:
+#   - homelab        -> all personal apps (you)
+#   - otterwiki-users + otterwiki-admins -> OtterWiki (shared editors + admins)
+#
+# Groups (structure) are declared here; MEMBERSHIP is managed in the Authentik
+# UI (Directory -> Groups). Add yourself to `homelab` and `otterwiki-admins`,
+# and shared people to `otterwiki-users`. If you ever lock yourself out, akadmin
+# (superuser) can always log in and fix group membership.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-access-control
+  namespace: security
+data:
+  access-control.yaml: |
+    version: 1
+    metadata:
+      name: access-control
+    entries:
+      # ── groups ──────────────────────────────────────────────────────
+      - model: authentik_core.group
+        id: group-homelab
+        state: present
+        identifiers:
+          name: homelab
+        attrs:
+          name: homelab
+      - model: authentik_core.group
+        id: group-otterwiki-users
+        state: present
+        identifiers:
+          name: otterwiki-users
+        attrs:
+          name: otterwiki-users
+
+      # ── homelab -> personal apps ────────────────────────────────────
+      # add a line here per app: bind homelab to its application.
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, miniflux]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, linkding]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, teslamate-grafana]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, changedetection]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, tautulli]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, sabnzbd]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, prometheus]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, homepage]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, longhorn]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, zigbee2mqtt]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, teslamate]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, kapowarr]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+
+      # ── OtterWiki -> shared editors + admins ────────────────────────
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, consolewiki]], group: !KeyOf group-otterwiki-users }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, consolewiki]], group: !Find [authentik_core.group, [name, otterwiki-admins]] }
+        attrs: { order: 1, enabled: true }

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
         - authentik-blueprint-teslamate-grafana
       configMaps:
         - authentik-blueprint-forward-auth
+        - authentik-blueprint-access-control
     server:
       replicas: 1
       initContainers:

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -15,3 +15,5 @@ resources:
   - ./blueprints/teslamate-grafana.yaml
   # forward-auth (proxy outpost) apps — all in one deterministic blueprint
   - ./blueprints/forward-auth.yaml
+  # declarative per-app access control (groups + application bindings)
+  - ./blueprints/access-control.yaml


### PR DESCRIPTION
## Lock down who can reach which app — in Git

Authentik applications are open to **all** logged-in users until a group is bound to them. Now that OtterWiki is shared (real multi-user), this adds declarative per-app access control so the shared accounts can't reach your personal apps.

### What it does
- **Groups** (`homelab`, `otterwiki-users`) declared as code. `otterwiki-admins` comes from #411.
- **Bindings:**
  - `homelab` → all 12 personal apps (miniflux, linkding, teslamate-grafana, changedetection, tautulli, sabnzbd, prometheus, homepage, longhorn, zigbee2mqtt, teslamate, kapowarr).
  - `otterwiki-users` + `otterwiki-admins` → OtterWiki.

Structure (groups + bindings) lives in Git; **membership stays UI-managed** (humans in the UI), per the access model we discussed.

### Merge order
Merge **after #411** — this references the `otterwiki-admins` group created there. (`!Find` resolves at apply time, so the build is fine regardless, but the binding needs the group to exist.)

### ⚠️ Important: add yourself before relying on it
Once bindings exist, only group members can access each app. **After merge, add your user to `homelab` and `otterwiki-admins`** (Directory → Groups), or you'll be denied your own apps. Recovery if you lock yourself out: **akadmin** (superuser) can always log into Authentik and fix membership — the admin interface is never gated by app bindings.

### Verification (I'll do post-merge)
This is the first use of policy bindings via blueprint, so I'll confirm: the bindings actually applied (worker logs + the apps' binding lists via API), you retain access as a `homelab` member, and a non-member is denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)