### PR TITLE
feat(mealie): sign in with Authentik (OIDC) + access control

### DIFF
--- a/kubernetes/apps/default/mealie/app/externalsecret.yaml
+++ b/kubernetes/apps/default/mealie/app/externalsecret.yaml
@@ -15,6 +15,9 @@ spec:
     template:
       engineVersion: v2
       data:
+        # SSO (Authentik OAuth2 client — must match the blueprint)
+        OIDC_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
+        OIDC_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
         # App
         DB_ENGINE: postgres
         POSTGRES_USER: "{{ .POSTGRES_USER }}"

--- a/kubernetes/apps/default/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mealie/app/helmrelease.yaml
@@ -47,6 +47,15 @@ spec:
               TZ: America/Chicago
               LOG_LEVEL: info
               API_DOCS: "true"
+              # SSO via Authentik (client id/secret come from mealie-secret).
+              # Local login kept as break-glass (no auto-redirect). Matches the
+              # existing user by email, so your recipes stay on your account.
+              OIDC_AUTH_ENABLED: "true"
+              OIDC_PROVIDER_NAME: Authentik
+              OIDC_CONFIGURATION_URL: https://auth.kalde.in/application/o/mealie/.well-known/openid-configuration
+              OIDC_SIGNUP_ENABLED: "true"
+              OIDC_USER_CLAIM: email
+              OIDC_REMEMBER_ME: "true"
             envFrom: *envFrom
             probes:
               liveness: &probes

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -75,6 +75,9 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, kapowarr]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, mealie]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── OtterWiki -> shared editors + admins ────────────────────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/mealie.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/mealie.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-mealie
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-mealie
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        mealie.yaml: |
+          version: 1
+          metadata:
+            name: mealie
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-mealie
+              state: present
+              identifiers:
+                name: mealie
+              attrs:
+                name: mealie
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                grant_types:
+                  - authorization_code
+                  - refresh_token
+                redirect_uris:
+                  - url: ^https://mealie\.kalde\.in/login.*
+                    matching_mode: regex
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-mealie
+              state: present
+              identifiers:
+                slug: mealie
+              attrs:
+                name: Mealie
+                slug: mealie
+                provider: !KeyOf provider-mealie
+                meta_launch_url: https://mealie.kalde.in
+                meta_description: Recipes
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: mealie
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -54,6 +54,7 @@ spec:
         - authentik-blueprint-miniflux
         - authentik-blueprint-linkding
         - authentik-blueprint-teslamate-grafana
+        - authentik-blueprint-mealie
       configMaps:
         - authentik-blueprint-forward-auth
         - authentik-blueprint-access-control

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./blueprints/miniflux.yaml
   - ./blueprints/linkding.yaml
   - ./blueprints/teslamate-grafana.yaml
+  - ./blueprints/mealie.yaml
   # forward-auth (proxy outpost) apps — all in one deterministic blueprint
   - ./blueprints/forward-auth.yaml
   # declarative per-app access control (groups + application bindings)


### PR DESCRIPTION
## OIDC for Mealie (`mealie.kalde.in`)

Single-user recipe app, native OIDC — same clean pattern as Miniflux/Linkding, now with the access binding baked in.

### Changes
- **Authentik** — `blueprints/mealie.yaml`: OAuth2 provider + application (slug `mealie`, redirect `^https://mealie\.kalde\.in/login.*` regex per Mealie's `/login*` callback), `grant_types` set. ESO-rendered Secret.
- **Mealie** — `OIDC_AUTH_ENABLED` + Authentik discovery URL + `OIDC_USER_CLAIM=email`; client id/secret added to `mealie-secret`. Local login kept as **break-glass**.
- **access-control** — bind `homelab` to the `mealie` application (locked to you by default).

### Requires (before merge)
Add to the existing **`mealie`** 1Password item:
- `OAUTH_CLIENT_ID`
- `OAUTH_CLIENT_SECRET`

### Behavior
- Login page gets a **"Login with Authentik"** button; matches your existing Mealie user by email, so all recipes stay put.
- Only `homelab` members can reach Mealie via SSO (Authentik denies others at the authorization step).

### After merge — I'll verify
New OIDC blueprint = a new secret volume, which can hit the discovery race (like Grafana #408). I'll confirm the provider got created (and `rollout restart authentik-worker` if it lags), then test the SSO button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)