### PR TITLE
feat(paperless): sign in with Authentik (OIDC) + access control

### DIFF
--- a/kubernetes/apps/default/paperless-ngx/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/externalsecret.yaml
@@ -19,6 +19,11 @@ spec:
 
         PAPERLESS_SECRET_KEY: "{{ .PAPERLESS_SECRETKEY }}"
 
+        # SSO (Authentik OIDC via allauth) — JSON holds the OAuth client.
+        # client id/secret must match the authentik blueprint.
+        PAPERLESS_SOCIALACCOUNT_PROVIDERS: |-
+          {"openid_connect":{"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"authentik","name":"Authentik","client_id":"{{ .OAUTH_CLIENT_ID }}","secret":"{{ .OAUTH_CLIENT_SECRET }}","settings":{"server_url":"https://auth.kalde.in/application/o/paperless/.well-known/openid-configuration","fetch_userinfo":true}}],"SCOPE":["openid","profile","email"]}}
+
         PAPERLESS_DBNAME: paperless
         PAPERLESS_DBUSER: "{{ .POSTGRES_USER }}"
         PAPERLESS_DBPASS: "{{ .POSTGRES_PASS }}"

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -56,6 +56,12 @@ spec:
               PAPERLESS_URL: https://documents.kalde.in
               PAPERLESS_CONSUMER_POLLING: 60
               PAPERLESS_CONSUMER_RECURSIVE: "true"
+              # SSO via Authentik (allauth OIDC). The provider JSON (with the
+              # client id/secret) is in paperless-ngx-secret. Local login kept
+              # as fallback (shared app); link existing accounts by email.
+              PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
+              PAPERLESS_SOCIAL_AUTO_SIGNUP: "true"
+              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "true"
             envFrom: *envFrom
             resources:
               requests:

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -36,6 +36,13 @@ data:
           name: otterwiki-users
         attrs:
           name: otterwiki-users
+      - model: authentik_core.group
+        id: group-paperless-users
+        state: present
+        identifiers:
+          name: paperless-users
+        attrs:
+          name: paperless-users
 
       # ── homelab -> personal apps ────────────────────────────────────
       # add a line here per app: bind homelab to its application.
@@ -78,6 +85,14 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, mealie]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+
+      # ── Paperless -> you + shared users (multi-user, OIDC) ──────────
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, paperless]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, paperless]], group: !KeyOf group-paperless-users }
+        attrs: { order: 1, enabled: true }
 
       # ── OtterWiki -> shared editors + admins ────────────────────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/paperless.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/paperless.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-paperless
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-paperless
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        paperless.yaml: |
+          version: 1
+          metadata:
+            name: paperless
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-paperless
+              state: present
+              identifiers:
+                name: paperless
+              attrs:
+                name: paperless
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                grant_types:
+                  - authorization_code
+                  - refresh_token
+                redirect_uris:
+                  - url: https://documents.kalde.in/accounts/oidc/authentik/login/callback/
+                    matching_mode: strict
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-paperless
+              state: present
+              identifiers:
+                slug: paperless
+              attrs:
+                name: Paperless
+                slug: paperless
+                provider: !KeyOf provider-paperless
+                meta_launch_url: https://documents.kalde.in
+                meta_description: Documents
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: paperless-ngx
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
         - authentik-blueprint-linkding
         - authentik-blueprint-teslamate-grafana
         - authentik-blueprint-mealie
+        - authentik-blueprint-paperless
       configMaps:
         - authentik-blueprint-forward-auth
         - authentik-blueprint-access-control

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./blueprints/linkding.yaml
   - ./blueprints/teslamate-grafana.yaml
   - ./blueprints/mealie.yaml
+  - ./blueprints/paperless.yaml
   # forward-auth (proxy outpost) apps — all in one deterministic blueprint
   - ./blueprints/forward-auth.yaml
   # declarative per-app access control (groups + application bindings)


### PR DESCRIPTION
## OIDC for Paperless-ngx (`documents.kalde.in`)

Shared documents app (3 users), so OIDC via allauth **plus** local login kept as fallback, and a `paperless-users` group so the shared accounts aren't locked out.

### Changes
- **Authentik** — `blueprints/paperless.yaml`: OAuth2 provider + application (slug `paperless`, redirect `https://documents.kalde.in/accounts/oidc/authentik/login/callback/`, `grant_types` set). ESO Secret.
- **Paperless** — `PAPERLESS_APPS=allauth...openid_connect` + auto-signup; the `PAPERLESS_SOCIALACCOUNT_PROVIDERS` JSON (with PKCE, client id/secret) rendered into `paperless-ngx-secret`.
- **access-control** — new `paperless-users` group; bind `homelab` + `paperless-users` to the Paperless application.

### ⚠️ Before you merge — add the 1Password fields FIRST
This is the step that bit us on Mealie (Helm rolled the whole Authentik release back). Add to the **`paperless-ngx`** 1Password item, **exactly one each, no duplicates**:
- `OAUTH_CLIENT_ID`  (`openssl rand -hex 20`)
- `OAUTH_CLIENT_SECRET`  (`openssl rand -hex 64`)

Then merge.

### Account linking (multi-user)
- Existing users keep local login. To link an existing Paperless account to Authentik: log in locally, then **connect the Authentik account** in Paperless settings (avoids a duplicate). First OIDC login with a matching email also links.
- For the shared people: create their Authentik accounts (same email) and add them to **`paperless-users`**.

### After merge — I'll verify
Provider created (restart worker if the discovery race hits), client_id match, both access bindings landed, and the SSO button appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)