### PR TITLE
feat(stirling-pdf): sign in with Authentik (OIDC) + access control

### DIFF
--- a/kubernetes/apps/default/stirling-pdf/app/externalsecret.yaml
+++ b/kubernetes/apps/default/stirling-pdf/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: stirling-pdf
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: stirling-pdf-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Authentik OAuth2 client (must match the blueprint)
+        SECURITY_OAUTH2_CLIENTID: "{{ .OAUTH_CLIENT_ID }}"
+        SECURITY_OAUTH2_CLIENTSECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: stirling-pdf
+  refreshInterval: 5m

--- a/kubernetes/apps/default/stirling-pdf/app/helmrelease.yaml
+++ b/kubernetes/apps/default/stirling-pdf/app/helmrelease.yaml
@@ -26,6 +26,20 @@ spec:
               DISABLE_ADDITIONAL_FEATURES: "false"
               LANGS: en_US
               SYSTEM_DEFAULTLOCALE: en-US
+              # SSO via Authentik. Enables Stirling's login system + OAuth2.
+              # client id/secret come from stirling-pdf-secret. provider name
+              # "authentik" sets the redirect path /login/oauth2/code/authentik.
+              SECURITY_ENABLELOGIN: "true"
+              SECURITY_OAUTH2_ENABLED: "true"
+              SECURITY_OAUTH2_PROVIDER: authentik
+              SECURITY_OAUTH2_ISSUER: https://auth.kalde.in/application/o/stirling-pdf/
+              SECURITY_OAUTH2_SCOPES: "openid, profile, email"
+              SECURITY_OAUTH2_USEASUSERNAME: email
+              SECURITY_OAUTH2_AUTOCREATEUSER: "true"
+              SECURITY_OAUTH2_BLOCKREGISTRATION: "false"
+            envFrom:
+              - secretRef:
+                  name: stirling-pdf-secret
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/default/stirling-pdf/app/kustomization.yaml
+++ b/kubernetes/apps/default/stirling-pdf/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 namespace: default
 resources:
   - ./ocirepository.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -85,6 +85,9 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, mealie]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, stirling-pdf]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── Paperless -> you + shared users (multi-user, OIDC) ──────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/stirling-pdf.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/stirling-pdf.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-stirling-pdf
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-stirling-pdf
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        stirling-pdf.yaml: |
+          version: 1
+          metadata:
+            name: stirling-pdf
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-stirling-pdf
+              state: present
+              identifiers:
+                name: stirling-pdf
+              attrs:
+                name: stirling-pdf
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                grant_types:
+                  - authorization_code
+                  - refresh_token
+                redirect_uris:
+                  - url: https://stirling-pdf.kalde.in/login/oauth2/code/authentik
+                    matching_mode: strict
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-stirling-pdf
+              state: present
+              identifiers:
+                slug: stirling-pdf
+              attrs:
+                name: Stirling-PDF
+                slug: stirling-pdf
+                provider: !KeyOf provider-stirling-pdf
+                meta_launch_url: https://stirling-pdf.kalde.in
+                meta_description: PDF tools
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: stirling-pdf
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
         - authentik-blueprint-teslamate-grafana
         - authentik-blueprint-mealie
         - authentik-blueprint-paperless
+        - authentik-blueprint-stirling-pdf
       configMaps:
         - authentik-blueprint-forward-auth
         - authentik-blueprint-access-control

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./blueprints/teslamate-grafana.yaml
   - ./blueprints/mealie.yaml
   - ./blueprints/paperless.yaml
+  - ./blueprints/stirling-pdf.yaml
   # forward-auth (proxy outpost) apps — all in one deterministic blueprint
   - ./blueprints/forward-auth.yaml
   # declarative per-app access control (groups + application bindings)


### PR DESCRIPTION
## OIDC for Stirling-PDF (`stirling-pdf.kalde.in`)

It currently has **no auth** (internal-only). This enables Stirling's login system and gates it with Authentik OIDC. Single-user → `homelab`-bound.

### Changes
- **Authentik** — `blueprints/stirling-pdf.yaml`: OAuth2 provider + application (slug `stirling-pdf`, redirect `https://stirling-pdf.kalde.in/login/oauth2/code/authentik`). The provider name `authentik` is what makes the callback path `/authentik` (Stirling/Spring quirk — must match `SECURITY_OAUTH2_PROVIDER`).
- **Stirling** — `SECURITY_ENABLELOGIN` + `SECURITY_OAUTH2_*` env; new `stirling-pdf-secret` externalsecret for the client id/secret.
- **access-control** — bind `homelab` to the stirling-pdf application.

### ⚠️ Before you merge — create the 1Password item FIRST
Create a **new** `stirling-pdf` 1Password item (same vault), **exactly one each, no duplicates**:
- `OAUTH_CLIENT_ID`  (`openssl rand -hex 20`)
- `OAUTH_CLIENT_SECRET`  (`openssl rand -hex 64`)

Then merge. (This avoids the Helm-rollback we hit on Mealie when the secret was unsyncable at mount time.)

### Notes
- No existing users (it had no login), so first OIDC login auto-creates your account (`SECURITY_OAUTH2_AUTOCREATEUSER`). If admin-only features are missing, we may need to set the first user's role — I'll check post-merge.
- Stirling+Authentik has historically been finicky about the issuer; using the per-app issuer `…/application/o/stirling-pdf/` with discovery.

### After merge — I'll verify
Provider created (worker restart if discovery race), client_id match, access binding landed (worker restart, since it's a new app), login enabled, and the SSO button works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)