### PR TITLE
feat(romm): sign in with Authentik (OIDC) + access control

### DIFF
--- a/kubernetes/apps/default/romm/app/externalsecret.yaml
+++ b/kubernetes/apps/default/romm/app/externalsecret.yaml
@@ -15,6 +15,9 @@ spec:
     template:
       engineVersion: v2
       data:
+        # SSO (Authentik OAuth2 client — must match the blueprint)
+        OIDC_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
+        OIDC_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
         # App
         ROMM_AUTH_SECRET_KEY: "{{ .ROMM_AUTH_SECRET_KEY }}"
         IGDB_CLIENT_ID: "{{ .IGDB_CLIENT_ID }}"

--- a/kubernetes/apps/default/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/default/romm/app/helmrelease.yaml
@@ -47,6 +47,12 @@ spec:
               DISABLE_DOWNLOAD_ENDPOINT_AUTH: "true"
               HASHEOUS_API_ENABLED: "true"
               PLAYMATCH_API_ENABLED: "true"
+              # SSO via Authentik (client id/secret come from romm-secret).
+              # Local login kept as fallback; matches existing user by email.
+              OIDC_ENABLED: "true"
+              OIDC_PROVIDER: authentik
+              OIDC_REDIRECT_URI: https://romm.kalde.in/api/oauth/openid
+              OIDC_SERVER_APPLICATION_URL: https://auth.kalde.in/application/o/romm
             envFrom: *envFrom
             probes:
               liveness: &probes

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -88,6 +88,9 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, stirling-pdf]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, romm]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── Paperless -> you + shared users (multi-user, OIDC) ──────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/romm.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/romm.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-romm
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-romm
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        romm.yaml: |
+          version: 1
+          metadata:
+            name: romm
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-romm
+              state: present
+              identifiers:
+                name: romm
+              attrs:
+                name: romm
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                grant_types:
+                  - authorization_code
+                  - refresh_token
+                redirect_uris:
+                  - url: https://romm.kalde.in/api/oauth/openid
+                    matching_mode: strict
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-romm
+              state: present
+              identifiers:
+                slug: romm
+              attrs:
+                name: RomM
+                slug: romm
+                provider: !KeyOf provider-romm
+                meta_launch_url: https://romm.kalde.in
+                meta_description: ROM library
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: romm
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -57,6 +57,7 @@ spec:
         - authentik-blueprint-mealie
         - authentik-blueprint-paperless
         - authentik-blueprint-stirling-pdf
+        - authentik-blueprint-romm
       configMaps:
         - authentik-blueprint-forward-auth
         - authentik-blueprint-access-control

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./blueprints/mealie.yaml
   - ./blueprints/paperless.yaml
   - ./blueprints/stirling-pdf.yaml
+  - ./blueprints/romm.yaml
   # forward-auth (proxy outpost) apps — all in one deterministic blueprint
   - ./blueprints/forward-auth.yaml
   # declarative per-app access control (groups + application bindings)


### PR DESCRIPTION
## OIDC for Romm (`romm.kalde.in`)

Confirmed Romm supports native OIDC. Single-user → `homelab`-bound. Same env-based pattern as Mealie.

### Changes
- **Authentik** — `blueprints/romm.yaml`: OAuth2 provider + application (slug `romm`, redirect `https://romm.kalde.in/api/oauth/openid`), `grant_types` set.
- **Romm** — `OIDC_ENABLED`, `OIDC_PROVIDER=authentik`, `OIDC_SERVER_APPLICATION_URL=https://auth.kalde.in/application/o/romm`; client id/secret added to `romm-secret`. Local login kept as fallback.
- **access-control** — bind `homelab` to the romm application.

### ⚠️ Before you merge — add the 1Password fields FIRST
Add to the existing **`romm`** 1Password item, exactly one each, no duplicates:
- `OAUTH_CLIENT_ID`  (`openssl rand -hex 20`)
- `OAUTH_CLIENT_SECRET`  (`openssl rand -hex 64`)

### ⚠️ Likely blocked by the same DNS issue as Stirling
Romm does **server-side** OIDC calls (token + JWKS) to `auth.kalde.in`, same as Stirling — which is currently failing because pods resolve `auth.kalde.in` out through Cloudflare and hairpin back, blowing the timeout. **Romm will probably hit this too.** The real fix is making `auth.kalde.in` resolve to the internal gateway in-cluster — that unblocks Stirling + Romm and hardens every OIDC app. Recommend we do that DNS fix alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)