### PR TITLE
fix(coredns): resolve auth.kalde.in to internal gateway in-cluster

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -29,6 +29,25 @@ spec:
       clusterIP: "10.43.0.10"
     replicaCount: 2
     servers:
+      # Resolve auth.kalde.in (the Authentik OIDC issuer) to the INTERNAL
+      # gateway so server-side OIDC calls from pods (discovery/token/JWKS) stay
+      # in-cluster instead of hairpinning out through Cloudflare. Pi-hole returns
+      # the public Cloudflare record for auth.kalde.in, and that round-trip is
+      # slow enough to time out some apps' JWKS fetch (e.g. Stirling-PDF, Romm).
+      # IPv4-only + authoritative (no fallthrough) so AAAA returns NODATA and
+      # clients use the v4 internal gateway rather than the Cloudflare IPv6.
+      # More specific than the kalde.in block below, so it wins for this name.
+      - zones:
+          - zone: auth.kalde.in
+            scheme: dns://
+        port: 53
+        plugins:
+          - name: errors
+          - name: cache
+            parameters: 30
+          - name: hosts
+            configBlock: |-
+              192.168.10.252 auth.kalde.in
       # Forward kalde.in queries to Pi-hole for split-horizon DNS
       - zones:
           - zone: kalde.in


### PR DESCRIPTION
## Problem
Server-side OIDC calls from pods to the Authentik issuer (`auth.kalde.in`) were leaving the cluster. From a pod, `auth.kalde.in` resolves to **Cloudflare** (`2606:4700:…`), so token/JWKS fetches hairpin out through the internet and back. That latency times out some apps' JWKS fetch:
- **Stirling-PDF** fails after the token exchange: `JwtException: ... GET .../jwks/: Read timed out` → "no token received".
- **Romm** (#416) does the same server-side calls and would hit it too.
- The OIDC apps that "work" (Miniflux/Mealie/Paperless/Grafana) are just tolerating the latency.

Confirmed the internal gateway (`192.168.10.252`) serves `auth.kalde.in` directly (→ 200); pods just weren't resolving there.

## Fix
A dedicated, more-specific CoreDNS server block resolves **`auth.kalde.in` → `192.168.10.252`** (internal gateway) via the `hosts` plugin:
```
dns://auth.kalde.in:53 {
    errors
    cache 30
    hosts { 192.168.10.252 auth.kalde.in }
}
```
- **IPv4-only + authoritative** (no `fallthrough`) so `AAAA` returns NODATA and clients use the v4 internal gateway instead of the Cloudflare IPv6.
- More specific than the existing `kalde.in → Pi-hole` block, so it wins for this one name; **all other `kalde.in` resolution is unchanged**.

## Safety
- Rendered the actual Corefile from the chart (v1.46.0) and confirmed it's valid — no risk of CoreDNS crash-looping on a bad config.
- Additive and surgical (one hostname). If anything misbehaves, revert this commit and CoreDNS returns to the prior behavior.

## After merge — I'll verify
`auth.kalde.in` resolves to `192.168.10.252` from a pod, Stirling-PDF login completes end-to-end, and Romm works once #416 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)