### PR TITLE
fix(coredns): drop autopath so the auth.kalde.in override applies

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -79,8 +79,13 @@ spec:
             configBlock: |-
               pods verified
               fallthrough in-addr.arpa ip6.arpa
-          - name: autopath
-            parameters: "@kubernetes"
+          # NOTE: autopath is intentionally NOT enabled. It server-side-follows
+          # the search-domain path and re-resolves the bare name *inside this
+          # block* via the upstream forward below — which bypasses the dedicated
+          # `auth.kalde.in` server block and sends pods' OIDC issuer lookups out
+          # to Cloudflare instead of the internal gateway. Without autopath the
+          # resolver falls through to the bare name, which the auth.kalde.in
+          # block answers internally. (Costs a few extra search-domain queries.)
           - name: forward
             parameters: . /etc/resolv.conf
           - name: cache


### PR DESCRIPTION
## Follow-up to #417 — that fix was being bypassed

#417 added a dedicated `auth.kalde.in → 192.168.10.252` server block, but Stirling-PDF still failed. Root cause, confirmed by query:
```
bare   auth.kalde.in.                          -> 192.168.10.252   ✅ (my block)
search auth.kalde.in.default.svc.cluster.local -> Cloudflare       ❌ (A + AAAA)
```
Pods (ndots:5) send the **search-domain form first**. `autopath @kubernetes` server-side-follows the search path and re-resolves the bare name **inside the `.:53` block** via its upstream `forward` — so it never consults the dedicated `auth.kalde.in` block and hands back the public Cloudflare record. The pod then hairpins and the JWKS fetch times out, exactly as before.

## Fix
Remove `autopath @kubernetes`. Without it the resolver does normal search-domain iteration: the `cluster.local` forms return NXDOMAIN (the `kubernetes` plugin is authoritative), then it falls through to the bare `auth.kalde.in`, which the dedicated block answers internally (A → gateway, AAAA → NODATA).

- autopath is only a **query-count optimization** — not in CoreDNS's defaults. Cost: a few extra search-domain queries per external lookup. No functional change otherwise.
- Rendered the Corefile (chart 1.46.0) to confirm it's valid (no crash-loop risk).

## After merge — I'll verify
`auth.kalde.in.default.svc.cluster.local` resolves to `192.168.10.252` from a pod, restart Stirling (clear its JVM DNS cache), and confirm the login completes end-to-end. Then Romm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)