### PR TITLE
fix(stirling-pdf): disable Spring virtual threads (OIDC JWKS regression)

### DIFF
--- a/kubernetes/apps/default/stirling-pdf/app/helmrelease.yaml
+++ b/kubernetes/apps/default/stirling-pdf/app/helmrelease.yaml
@@ -23,6 +23,14 @@ spec:
               tag: 2.13.1-fat
             env:
               TZ: America/Chicago
+              # Stirling's OIDC JWKS fetch (Nimbus via blocking HttpURLConnection)
+              # times out only inside the JVM — curl/python pull the same endpoint
+              # from this pod in <1s. It's a known upstream regression (works on
+              # 2.4.0, broke ~2.9.x; Stirling-Tools/Stirling-PDF#6078) that tracks
+              # the image enabling Spring virtual threads, which pin/stall the
+              # blocking JWKS read. Disable them. JDK_JAVA_OPTIONS is processed
+              # after the image's JAVA_TOOL_OPTIONS, so this -D wins (verified).
+              JDK_JAVA_OPTIONS: -Dspring.threads.virtual.enabled=false
               DISABLE_ADDITIONAL_FEATURES: "false"
               LANGS: en_US
               SYSTEM_DEFAULTLOCALE: en-US


### PR DESCRIPTION
Re-adds the JVM-options fix that was dropped when #419 merged (only the `hostAliases` pin landed).

The OIDC JWKS fetch times out **only inside the JVM** — curl and python pull the same endpoint from the pod in <1s. It's a confirmed upstream regression (works on `2.4.0`, broke ~`2.9.x`; [Stirling-Tools/Stirling-PDF#6078](https://github.com/Stirling-Tools/Stirling-PDF/issues/6078), another k8s home-ops user hits it too) that lines up with the image enabling **Spring virtual threads** — whose pinning stalls Nimbus's blocking `HttpURLConnection` JWKS read.

Sets `-Dspring.threads.virtual.enabled=false` via `JDK_JAVA_OPTIONS`. Verified the precedence: `JDK_JAVA_OPTIONS` is applied after the image's `JAVA_TOOL_OPTIONS`, so the override wins (`-XshowSettings:properties` → `spring.threads.virtual.enabled = false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)