### PR TITLE
feat(romm): disable local password login (Authentik-only)

### DIFF
--- a/kubernetes/apps/default/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/default/romm/app/helmrelease.yaml
@@ -48,11 +48,14 @@ spec:
               HASHEOUS_API_ENABLED: "true"
               PLAYMATCH_API_ENABLED: "true"
               # SSO via Authentik (client id/secret come from romm-secret).
-              # Local login kept as fallback; matches existing user by email.
+              # Matches the existing user by email. Local password login is
+              # disabled (DISABLE_USERPASS_LOGIN) — only Authentik. Break-glass
+              # if Authentik is down: set this to "false" in Git and reconcile.
               OIDC_ENABLED: "true"
               OIDC_PROVIDER: authentik
               OIDC_REDIRECT_URI: https://romm.kalde.in/api/oauth/openid
               OIDC_SERVER_APPLICATION_URL: https://auth.kalde.in/application/o/romm
+              DISABLE_USERPASS_LOGIN: "true"
             envFrom: *envFrom
             probes:
               liveness: &probes


### PR DESCRIPTION
OIDC is verified working, so disable the username/password form via `DISABLE_USERPASS_LOGIN=true` — Romm authenticates only through Authentik.

**Break-glass:** if Authentik is ever down, set this back to `false` in Git and reconcile to restore local login.

After merge I'll verify the form is gone and report whether Romm auto-redirects to Authentik or shows the button (and chase an auto-redirect option if it's the latter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)