### PR TITLE
feat(arr): gate sonarr/radarr/lidarr UIs behind Authentik (forward-auth)

### DIFF
--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -85,22 +85,12 @@ spec:
           http:
             port: *port
 
-    route:
-      app:
-        # Defined in Homepage's services.yaml (with widget) instead of via
-        # discovery, since widget API keys can't be templated in annotations.
-        hostnames: ["{{ .Release.Name }}.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: lidarr has no OIDC, so the UI is exposed only via the
+    # Authentik embedded proxy outpost. See ./httproute.yaml (lidarr-auth),
+    # which sends lidarr.kalde.in to authentik-server. The API stays reachable
+    # in-cluster via the lidarr Service (Homepage uses svc DNS), and the
+    # outpost forwards from a local IP so lidarr's DisabledForLocalAddresses
+    # auth bypasses — no double-login.
 
     persistence:
       config:

--- a/kubernetes/apps/media/lidarr/app/httproute.yaml
+++ b/kubernetes/apps/media/lidarr/app/httproute.yaml
@@ -1,0 +1,29 @@
+---
+# lidarr is fronted by the Authentik embedded proxy outpost: route the public
+# host to authentik-server (security ns), which authenticates and then proxies
+# to the lidarr Service internally. Cross-namespace backendRef is permitted by
+# the ReferenceGrant in the security namespace. Homepage is defined in
+# Homepage's own services.yaml (widget), so no gethomepage annotations here.
+# Name is "lidarr-auth", NOT "lidarr": a same-named standalone route races with
+# the Helm prune of the old app-template route during migration.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: lidarr-auth
+  namespace: media
+spec:
+  hostnames:
+    - lidarr.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/media/lidarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/lidarr/app/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: media
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./ocirepository.yaml
   - ./cronjobs
 configMapGenerator:

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -71,22 +71,12 @@ spec:
           http:
             port: *port
 
-    route:
-      app:
-        # Defined in Homepage's services.yaml (with widget) instead of via
-        # discovery, since widget API keys can't be templated in annotations.
-        hostnames: ["{{ .Release.Name }}.kalde.in", "radarr.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: radarr has no OIDC, so the UI is exposed only via the
+    # Authentik embedded proxy outpost. See ./httproute.yaml (radarr-auth),
+    # which sends radarr.kalde.in to authentik-server. The API stays reachable
+    # in-cluster via the radarr Service (Seerr/Homepage use svc DNS), and the
+    # outpost forwards from a local IP so radarr's DisabledForLocalAddresses
+    # auth bypasses — no double-login.
 
     persistence:
       config:

--- a/kubernetes/apps/media/radarr/app/httproute.yaml
+++ b/kubernetes/apps/media/radarr/app/httproute.yaml
@@ -1,0 +1,29 @@
+---
+# radarr is fronted by the Authentik embedded proxy outpost: route the public
+# host to authentik-server (security ns), which authenticates and then proxies
+# to the radarr Service internally. Cross-namespace backendRef is permitted by
+# the ReferenceGrant in the security namespace. Homepage is defined in
+# Homepage's own services.yaml (widget), so no gethomepage annotations here.
+# Name is "radarr-auth", NOT "radarr": a same-named standalone route races with
+# the Helm prune of the old app-template route during migration.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: radarr-auth
+  namespace: media
+spec:
+  hostnames:
+    - radarr.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/media/radarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr/app/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ./config-pvc.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./ocirepository.yaml
   - ./cronjobs

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -66,27 +66,12 @@ spec:
           http:
             port: *port
 
-    route:
-      app:
-        annotations:
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/name: Sonarr
-          gethomepage.dev/description: TV series management
-          gethomepage.dev/group: Media
-          gethomepage.dev/icon: sonarr.png
-          gethomepage.dev/href: https://sonarr.kalde.in
-        hostnames: ["{{ .Release.Name }}.kalde.in", "sonarr.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
+    # No direct route: sonarr has no OIDC, so the UI is exposed only via the
+    # Authentik embedded proxy outpost. See ./httproute.yaml (sonarr-auth),
+    # which sends sonarr.kalde.in to authentik-server. The API stays reachable
+    # in-cluster via the sonarr Service (Seerr/Homepage use svc DNS), and the
+    # outpost forwards from a local IP so sonarr's DisabledForLocalAddresses
+    # auth bypasses — no double-login.
 
     persistence:
       config:

--- a/kubernetes/apps/media/sonarr/app/httproute.yaml
+++ b/kubernetes/apps/media/sonarr/app/httproute.yaml
@@ -1,0 +1,37 @@
+---
+# sonarr is fronted by the Authentik embedded proxy outpost: route the public
+# host to authentik-server (security ns), which authenticates and then proxies
+# to the sonarr Service internally. Cross-namespace backendRef is permitted by
+# the ReferenceGrant in the security namespace.
+# Name is "sonarr-auth", NOT "sonarr": a same-named standalone route races with
+# the Helm prune of the old app-template route during migration.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sonarr-auth
+  namespace: media
+  annotations:
+    gethomepage.dev/enabled: "true"
+    # Route is sonarr-auth; point status detection at the real app pods.
+    gethomepage.dev/app: sonarr
+    gethomepage.dev/name: Sonarr
+    gethomepage.dev/description: TV series management
+    gethomepage.dev/group: Media
+    gethomepage.dev/icon: sonarr.png
+    gethomepage.dev/href: https://sonarr.kalde.in
+spec:
+  hostnames:
+    - sonarr.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/media/sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr/app/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./ocirepository.yaml
   - ./cronjobs

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -91,6 +91,15 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, romm]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, sonarr]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, radarr]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, lidarr]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── Paperless -> you + shared users (multi-user, OIDC) ──────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -327,6 +327,87 @@ data:
           meta_description: Wiki
           policy_engine_mode: any
 
+      # ── sonarr ────────────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-sonarr
+        state: present
+        identifiers:
+          name: sonarr
+        attrs:
+          name: sonarr
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://sonarr.kalde.in
+          internal_host: http://sonarr.media.svc.cluster.local
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-sonarr
+        state: present
+        identifiers:
+          slug: sonarr
+        attrs:
+          name: Sonarr
+          slug: sonarr
+          provider: !KeyOf provider-sonarr
+          meta_launch_url: https://sonarr.kalde.in
+          meta_description: TV series management
+          policy_engine_mode: any
+
+      # ── radarr ────────────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-radarr
+        state: present
+        identifiers:
+          name: radarr
+        attrs:
+          name: radarr
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://radarr.kalde.in
+          internal_host: http://radarr.media.svc.cluster.local
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-radarr
+        state: present
+        identifiers:
+          slug: radarr
+        attrs:
+          name: Radarr
+          slug: radarr
+          provider: !KeyOf provider-radarr
+          meta_launch_url: https://radarr.kalde.in
+          meta_description: Movie management
+          policy_engine_mode: any
+
+      # ── lidarr ────────────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-lidarr
+        state: present
+        identifiers:
+          name: lidarr
+        attrs:
+          name: lidarr
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://lidarr.kalde.in
+          internal_host: http://lidarr.media.svc.cluster.local:8686
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-lidarr
+        state: present
+        identifiers:
+          slug: lidarr
+        attrs:
+          name: Lidarr
+          slug: lidarr
+          provider: !KeyOf provider-lidarr
+          meta_launch_url: https://lidarr.kalde.in
+          meta_description: Music management
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -344,3 +425,6 @@ data:
             - !KeyOf provider-teslamate
             - !KeyOf provider-kapowarr
             - !KeyOf provider-consolewiki
+            - !KeyOf provider-sonarr
+            - !KeyOf provider-radarr
+            - !KeyOf provider-lidarr


### PR DESCRIPTION
Gates the Sonarr/Radarr/Lidarr **UIs** with the Authentik embedded proxy outpost (same pattern as Tautulli/SABnzbd). They have no native OIDC, so this is forward-auth, not SSO-inside-the-app.

## Why this is safe (the integration risk is cleared)
- **Seerr** calls the *arr APIs via `radarr.media.svc.cluster.local` / `sonarr.media.svc.cluster.local` — Service DNS, bypasses the gateway/outpost. ✅
- **Homepage** widgets use Service DNS too (`http://radarr.media.svc...`). ✅
- No Bazarr/Prowlarr/Recyclarr deployed.
- All three are already `DisabledForLocalAddresses`, so the outpost (forwarding from a cluster-internal IP) bypasses their built-in auth → **no double-login**, no in-app changes.
- Bonus: radarr was `External` auth with no proxy in front (effectively unprotected externally) — this closes that.

## Changes
- **forward-auth blueprint**: proxy provider + application for each, added to the embedded outpost `providers` list.
- **access-control**: bind `homelab` to all three.
- **each app**: drop the app-template route, add an `<app>-auth` HTTPRoute → `authentik-server` (ReferenceGrant already covers `media`).

## After merge — I'll handle/verify
- Force-reconcile the media app Kustomizations if the route swap hits the Helm-prune race; restart the worker to land the new outpost providers + access bindings.
- Verify: each UI prompts Authentik then loads; **Seerr can still add a request**; **Homepage widgets still populate** (proves the API path is intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)