### PR TITLE
feat(dailytrace): gate behind Authentik via reverse-proxy (forward-auth)

### DIFF
--- a/kubernetes/apps/default/dailytrace/backend/helmrelease.yaml
+++ b/kubernetes/apps/default/dailytrace/backend/helmrelease.yaml
@@ -49,24 +49,9 @@ spec:
         ports:
           http:
             port: 8081
-    route:
-      backend:
-        hostnames: ["dailytrace.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - matches:
-              - path:
-                  type: PathPrefix
-                  value: "/api"
-            backendRefs:
-              - identifier: backend
-                port: 8081
+    # No direct route: dailytrace.kalde.in now goes through the dailytrace-proxy
+    # nginx behind the Authentik outpost (see ../proxy), which path-splits /api
+    # to this backend Service. The backend is reached internally via its Service.
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/kubernetes/apps/default/dailytrace/frontend/helmrelease.yaml
+++ b/kubernetes/apps/default/dailytrace/frontend/helmrelease.yaml
@@ -46,20 +46,9 @@ spec:
         ports:
           http:
             port: 8080
-    route:
-      frontend:
-        hostnames: ["dailytrace.kalde.in"]
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: frontend
-                port: 8080
+    # No direct route: dailytrace.kalde.in now goes through the dailytrace-proxy
+    # nginx behind the Authentik outpost (see ../proxy). The frontend is reached
+    # internally via its Service.
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/kubernetes/apps/default/dailytrace/ks.yaml
+++ b/kubernetes/apps/default/dailytrace/ks.yaml
@@ -21,6 +21,27 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: cluster-apps-dailytrace-proxy
+  namespace: flux-system
+spec:
+  # nginx that fronts frontend+backend as a single upstream behind Authentik
+  path: ./kubernetes/apps/default/dailytrace/proxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m
+  dependsOn:
+    - name: cluster-apps-dailytrace-frontend
+    - name: cluster-apps-dailytrace-backend
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: cluster-apps-dailytrace-backend
   namespace: flux-system
 spec:

--- a/kubernetes/apps/default/dailytrace/proxy/configmap.yaml
+++ b/kubernetes/apps/default/dailytrace/proxy/configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Single entry point in front of the dailytrace frontend + backend so the whole
+# app can sit behind ONE Authentik proxy-outpost upstream. Reproduces the
+# gateway path-split: /api -> backend, everything else -> frontend SPA.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dailytrace-proxy-nginx
+  namespace: default
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        server_name _;
+        client_max_body_size 100m;
+
+        # local health check for the proxy itself (does not hit the backend)
+        location = /healthz {
+            access_log off;
+            return 200 "ok\n";
+        }
+
+        # API requests -> backend (no path rewrite; backend expects /api prefix)
+        location /api {
+            proxy_pass http://dailytrace-backend.default.svc.cluster.local:8081;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # everything else -> frontend SPA
+        location / {
+            proxy_pass http://dailytrace-frontend.default.svc.cluster.local:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }

--- a/kubernetes/apps/default/dailytrace/proxy/helmrelease.yaml
+++ b/kubernetes/apps/default/dailytrace/proxy/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helm.toolkit.fluxcd.io/helmrelease_v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app dailytrace-proxy
+  namespace: default
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: dailytrace-proxy
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      dailytrace-proxy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: nginxinc/nginx-unprivileged
+              tag: 1.27-alpine
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: dailytrace-proxy
+        ports:
+          http:
+            port: 8080
+    persistence:
+      nginx-config:
+        type: configMap
+        name: dailytrace-proxy-nginx
+        globalMounts:
+          - path: /etc/nginx/conf.d/default.conf
+            subPath: default.conf
+            readOnly: true

--- a/kubernetes/apps/default/dailytrace/proxy/httproute.yaml
+++ b/kubernetes/apps/default/dailytrace/proxy/httproute.yaml
@@ -1,0 +1,27 @@
+---
+# dailytrace (no built-in login) is fronted by the Authentik embedded proxy
+# outpost: route the public host to authentik-server (security ns), which
+# authenticates and then proxies to the dailytrace-proxy nginx, which path-splits
+# /api -> backend and / -> frontend. Cross-namespace backendRef permitted by the
+# ReferenceGrant in the security namespace.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dailytrace-auth
+  namespace: default
+spec:
+  hostnames:
+    - dailytrace.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/dailytrace/proxy/kustomization.yaml
+++ b/kubernetes/apps/default/dailytrace/proxy/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./ocirepository.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/dailytrace/proxy/ocirepository.yaml
+++ b/kubernetes/apps/default/dailytrace/proxy/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dailytrace-proxy
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -100,6 +100,9 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, lidarr]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, dailytrace]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── Paperless -> you + shared users (multi-user, OIDC) ──────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -408,6 +408,35 @@ data:
           meta_description: Music management
           policy_engine_mode: any
 
+      # ── dailytrace ────────────────────────────────────────────────────
+      # Proxies to the dailytrace-proxy nginx, which path-splits /api -> backend
+      # and / -> frontend (the app itself has no login).
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-dailytrace
+        state: present
+        identifiers:
+          name: dailytrace
+        attrs:
+          name: dailytrace
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://dailytrace.kalde.in
+          internal_host: http://dailytrace-proxy.default.svc.cluster.local:8080
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-dailytrace
+        state: present
+        identifiers:
+          slug: dailytrace
+        attrs:
+          name: Dailytrace
+          slug: dailytrace
+          provider: !KeyOf provider-dailytrace
+          meta_launch_url: https://dailytrace.kalde.in
+          meta_description: Daily journal / tracker
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -428,3 +457,4 @@ data:
             - !KeyOf provider-sonarr
             - !KeyOf provider-radarr
             - !KeyOf provider-lidarr
+            - !KeyOf provider-dailytrace


### PR DESCRIPTION
dailytrace has **no built-in login** and is split **frontend (SPA) + backend (API)** at the gateway by path (`/api` → backend, `/` → frontend). The Authentik proxy outpost gates by host and proxies to a **single upstream**, so it can't keep that split directly.

Per your call, this adds a tiny **nginx reverse-proxy** (`dailytrace-proxy`) that reproduces the split and sits behind the outpost — **app images untouched**.

```
dailytrace.kalde.in → outpost (auth) → dailytrace-proxy (nginx)
                                          ├─ /api → dailytrace-backend:8081
                                          └─ /    → dailytrace-frontend:8080
```

### Changes
- **new `proxy/` component**: `nginx-unprivileged` + config ConfigMap + `dailytrace-auth` HTTPRoute → `authentik-server`; new Flux Kustomization `cluster-apps-dailytrace-proxy` (dependsOn frontend + backend).
- **frontend/backend**: drop their direct `dailytrace.kalde.in` routes (now reached only via Services / the proxy).
- **forward-auth blueprint**: proxy provider (`internal_host = dailytrace-proxy`) + application, added to the embedded outpost.
- **access-control**: bind `homelab`.

No secrets (forward-auth = ConfigMap blueprint, no rollback risk).

### After merge — I'll verify
nginx proxy pod healthy; `dailytrace.kalde.in` prompts Authentik then loads the SPA; **the SPA's `/api` calls succeed through the proxy** (the whole point); confirm the proxy's Service name matches the blueprint's `internal_host` and fix if app-template named it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)