### PR TITLE
fix(opencloud): set global service account via OC_ envs

### DIFF
--- a/kubernetes/apps/default/opencloud/app/externalsecret.yaml
+++ b/kubernetes/apps/default/opencloud/app/externalsecret.yaml
@@ -16,6 +16,12 @@ spec:
       engineVersion: v2
       data:
         IDM_ADMIN_PASSWORD: "{{ .IDM_ADMIN_PASSWORD }}"
+        # Global service account, applied to every service via OC_ envs. The
+        # rolling image's `sharing` service now requires a service account; the
+        # init-generated config on the PVC predates that and lacks one under
+        # `sharing:`, so set it globally here instead of relying on the config.
+        OC_SERVICE_ACCOUNT_ID: "{{ .OC_SERVICE_ACCOUNT_ID }}"
+        OC_SERVICE_ACCOUNT_SECRET: "{{ .OC_SERVICE_ACCOUNT_SECRET }}"
   dataFrom:
     - extract:
         key: opencloud


### PR DESCRIPTION
## Problem

OpenCloud was in `CrashLoopBackOff`. Root cause: the rolling image (`opencloudeu/opencloud-rolling:latest`) auto-upgraded to a version whose **`sharing` service now requires a service account**, but the `opencloud init`-generated config persisted on the `opencloud-config` PVC predates that requirement and has no `service_account` block under `sharing:` (every other service has one).

The sharing service exits fatally on the missing account, which takes down the single-binary `opencloud server` process — and with it the embedded NATS. That cascades into both containers failing:

- `app`: `The service account id has not been configured for sharing.`
- `collaboration`: `Failed to connect to NATS Server: nats: no servers available for connection`

The init container can't self-heal because it runs `opencloud init || true`, which refuses to modify an existing config.

## Fix

Surface `OC_SERVICE_ACCOUNT_ID` / `OC_SERVICE_ACCOUNT_SECRET` from the `opencloud` 1Password item through the external secret. They inject via the existing `envFrom` and set the service account **globally for every service**, so this is immune to future config-schema drift on the PVC.

## Follow-up (not in this PR)

The underlying trigger is the `:latest` rolling tag causing uncontrolled upgrades. Consider pinning to a digest like the home-assistant app does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)