### PR TITLE
feat(authentik): gate lease-inventory behind forward-auth

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./kapowarr/ks.yaml
   - ./kavita/ks.yaml
   - ./kometa/ks.yaml
+  - ./lease-inventory/ks.yaml
   - ./linkding/ks.yaml
   #- ./longhorn/ks.yaml
   - ./mealie/ks.yaml

--- a/kubernetes/apps/default/lease-inventory/app/httproute.yaml
+++ b/kubernetes/apps/default/lease-inventory/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+# lease-inventory has no built-in auth and its backend lives OUTSIDE the cluster
+# (the host-networked app on cerritos, 192.168.8.10:8892). Route the public host
+# to authentik-server (security ns), which authenticates via the embedded proxy
+# outpost and then proxies to that LAN backend (see the `leases` proxyprovider in
+# authentik's forward-auth blueprint). Internal-only. Cross-namespace backendRef
+# allowed by the ReferenceGrant in the security namespace.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: lease-inventory-auth
+  namespace: default
+spec:
+  hostnames:
+    - leases.kalde.in
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/lease-inventory/app/kustomization.yaml
+++ b/kubernetes/apps/default/lease-inventory/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./httproute.yaml

--- a/kubernetes/apps/default/lease-inventory/ks.yaml
+++ b/kubernetes/apps/default/lease-inventory/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-lease-inventory
+  namespace: flux-system
+spec:
+  # Route-only: leases.kalde.in -> Authentik embedded outpost -> the external
+  # lease-inventory app on cerritos. No in-cluster workload; the outpost binding
+  # lives in authentik's forward-auth blueprint.
+  path: ./kubernetes/apps/default/lease-inventory/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -103,6 +103,9 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, dailytrace]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, leases]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── Paperless -> you + shared users (multi-user, OIDC) ──────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -437,6 +437,35 @@ data:
           meta_description: Daily journal / tracker
           policy_engine_mode: any
 
+      # ── lease-inventory (external backend on cerritos, not in-cluster) ──
+      # internal_host is the host-networked lease-inventory app on cerritos
+      # (192.168.8.10:8892), reached over the LAN from the authentik-server pod.
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-leases
+        state: present
+        identifiers:
+          name: leases
+        attrs:
+          name: leases
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://leases.kalde.in
+          internal_host: http://192.168.8.10:8892
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-leases
+        state: present
+        identifiers:
+          slug: leases
+        attrs:
+          name: Lease Inventory
+          slug: leases
+          provider: !KeyOf provider-leases
+          meta_launch_url: https://leases.kalde.in
+          meta_description: Kea DHCP lease inventory
+          policy_engine_mode: any
+
       # ── embedded outpost: every forward-auth provider must be listed ──
       - model: authentik_outposts.outpost
         state: present
@@ -458,3 +487,4 @@ data:
             - !KeyOf provider-radarr
             - !KeyOf provider-lidarr
             - !KeyOf provider-dailytrace
+            - !KeyOf provider-leases


### PR DESCRIPTION
## What

Gates the new **lease-inventory** web app (a read-only view of Kea DHCP leases, enriched with reservation model names + OUI vendors) behind Authentik using the existing embedded proxy-outpost / forward-auth pattern.

Companion to the app itself, which lives in `calypso-deploy` (runs host-networked on cerritos at `192.168.8.10:8892`).

## Changes

- **`blueprints/forward-auth.yaml`** — new `leases` proxyprovider + application, registered in the embedded outpost. Unlike the other forward-auth apps, `internal_host` points **outside the cluster** (`http://192.168.8.10:8892`, the cerritos app) rather than a cluster Service.
- **`blueprints/access-control.yaml`** — binds the `homelab` group to the `leases` app (same as other personal apps).
- **`default/lease-inventory/`** (new) — internal-only `HTTPRoute` (`leases.kalde.in` → `authentik-server:80`) + Flux Kustomization.
- **`default/kustomization.yaml`** — registers the new `ks.yaml`.

## Flow

    browser -> leases.kalde.in
      -> internal gateway (192.168.10.252)
      -> authentik-server:80 (embedded outpost, SSO)
      -> http://192.168.8.10:8892 (cerritos lease-inventory app)

## Validation

`kustomize build` passes for `security/authentik/app`, `default/lease-inventory/app`, and the `default` aggregation.

## Verify after merge

- `leases.kalde.in` resolves (internal) and prompts Authentik login for a `homelab` member.
- The authentik-server pod can reach `192.168.8.10:8892` over the LAN (cluster egress).