### PR TITLE
fix(coredns): forward kalde.in to 192.168.8.10 (pi-hole moved from .10.80)

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
           - name: cache
             parameters: 30
           - name: forward
-            parameters: . 192.168.10.80
+            parameters: . 192.168.8.10
           - name: log
             configBlock: |-
               class error


### PR DESCRIPTION
## Problem

Cluster pods (notably the `actions-runner-system` runners) could not resolve `*.kalde.in` records such as `pr-299.beoftexas.kalde.in`.

Root cause: CoreDNS's `kalde.in` split-horizon forwarder pointed at `192.168.10.80`, which is no longer reachable — the Pi-hole moved to `192.168.8.10`. Every `kalde.in` lookup from inside the cluster timed out.

## Fix

Point the `kalde.in` forwarder at `192.168.8.10` (the current Pi-hole, which `external-dns-pihole` already writes records to).

## Verification

- Hot-patched the live `coredns` ConfigMap and restarted the deployment.
- In-cluster query via CoreDNS (`10.43.0.10`) now resolves `pr-299.beoftexas.kalde.in` → `192.168.10.35`.
- Live config and git now match, so Flux reconcile of this change is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)