### PR TITLE
feat(audiobookshelf): add audiobookshelf with NFS audiobook library

### DIFF
--- a/kubernetes/apps/default/audiobookshelf/app/config-pvc.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/config-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audiobookshelf-config-v1
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/kubernetes/apps/default/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/helmrelease.yaml
@@ -1,0 +1,126 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app audiobookshelf
+  namespace: default
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: audiobookshelf
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      audiobookshelf:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/advplyr/audiobookshelf
+              tag: 2.35.1
+            env:
+              TZ: America/Chicago
+              # Image defaults to PORT=80, which uid 1024 cannot bind.
+              PORT: &port 13378
+              CONFIG_PATH: /config
+              METADATA_PATH: /metadata
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthcheck
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthcheck
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 1
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1024
+            runAsGroup: 100
+            fsGroup: 100
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Audiobookshelf
+          gethomepage.dev/description: Audiobook library
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: audiobookshelf.png
+          gethomepage.dev/href: https://audiobookshelf.kalde.in
+        hostnames: ["{{ .Release.Name }}.kalde.in"]
+        parentRefs:
+          - name: external
+            namespace: kube-system
+            sectionName: https
+          - name: internal
+            namespace: kube-system
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+
+    persistence:
+      # SQLite database — keep it off NFS.
+      config:
+        enabled: true
+        existingClaim: audiobookshelf-config-v1
+        globalMounts:
+          - path: /config
+      metadata:
+        enabled: true
+        existingClaim: audiobookshelf-metadata-v1
+        globalMounts:
+          - path: /metadata
+      audiobooks:
+        enabled: true
+        type: nfs
+        server: 192.168.10.3
+        path: /volume1/share2/audiobooks
+        globalMounts:
+          - path: /audiobooks

--- a/kubernetes/apps/default/audiobookshelf/app/kustomization.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./config-pvc.yaml
+  - ./metadata-pvc.yaml

--- a/kubernetes/apps/default/audiobookshelf/app/metadata-pvc.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/metadata-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audiobookshelf-metadata-v1
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn

--- a/kubernetes/apps/default/audiobookshelf/app/ocirepository.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: &app audiobookshelf
+  namespace: default
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/default/audiobookshelf/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-audiobookshelf
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/default/audiobookshelf/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: default
 components:
   - ../../components/common
 resources:
+  - ./audiobookshelf/ks.yaml
   - ./changedetection/ks.yaml
   - ./collabora/ks.yaml
   - ./consolewiki/ks.yaml


### PR DESCRIPTION
Sets up an Audiobookshelf instance in the `default` namespace, following the same app-template pattern as kavita/romm.

## Storage
| Mount | Backing |
|---|---|
| `/audiobooks` | NFS `192.168.10.3:/volume1/share2/audiobooks` |
| `/config` | Longhorn PVC (5Gi) |
| `/metadata` | Longhorn PVC (20Gi) |

Config and metadata are on Longhorn rather than NFS deliberately: Audiobookshelf stores its state in SQLite, and SQLite locking over NFS risks database corruption.

## uid/gid
Runs as `runAsUser: 1024` / `runAsGroup: 100` as requested. This works out — the library dir on the NAS is `drwxrwsr-x 1026 users`, so gid 100 (`users`) grants read/write via the group bit. Same uid/gid pair immich already uses.

## Port
The upstream image defaults to `PORT=80`, which a non-root uid cannot bind, so `PORT` is overridden to `13378` and the service/probes follow.

## Verification
Rendered the chart with `helm template` and confirmed the deployment, mounts, service and route come out as intended. Then ran the real image in-cluster as a throwaway pod with this exact securityContext:
- starts as `uid=1024 gid=100(users)`
- SQLite db initializes cleanly, nusqlite3 extension loads
- `Listening on port :13378`
- `GET /healthcheck` → `OK` (the probe path used here)

Reachable at https://audiobookshelf.kalde.in once reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)