### PR TITLE
feat(authentik): add audiobookshelf OIDC provider

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -106,6 +106,9 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, leases]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, audiobookshelf]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── Paperless -> you + shared users (multi-user, OIDC) ──────────
       - model: authentik_policies.policybinding

--- a/kubernetes/apps/security/authentik/app/blueprints/audiobookshelf.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/audiobookshelf.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-blueprint-audiobookshelf
+  namespace: security
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: authentik-blueprint-audiobookshelf
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        audiobookshelf.yaml: |
+          version: 1
+          metadata:
+            name: audiobookshelf
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              id: provider-audiobookshelf
+              state: present
+              identifiers:
+                name: audiobookshelf
+              attrs:
+                name: audiobookshelf
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+                client_type: confidential
+                client_id: "{{ .OAUTH_CLIENT_ID }}"
+                client_secret: "{{ .OAUTH_CLIENT_SECRET }}"
+                grant_types:
+                  - authorization_code
+                  - refresh_token
+                redirect_uris:
+                  # Web login callback.
+                  - url: https://audiobookshelf.kalde.in/auth/openid/callback
+                    matching_mode: strict
+                  # The iOS/Android apps complete the flow on a custom scheme.
+                  - url: audiobookshelf://oauth
+                    matching_mode: strict
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+            - model: authentik_core.application
+              id: app-audiobookshelf
+              state: present
+              identifiers:
+                slug: audiobookshelf
+              attrs:
+                name: Audiobookshelf
+                slug: audiobookshelf
+                provider: !KeyOf provider-audiobookshelf
+                meta_launch_url: https://audiobookshelf.kalde.in
+                meta_description: Audiobook library
+                policy_engine_mode: any
+  dataFrom:
+    - extract:
+        key: audiobookshelf
+  refreshInterval: 5m

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
     # per-app SSO definitions, applied by the worker (see ./blueprints/)
     blueprints:
       secrets:
+        - authentik-blueprint-audiobookshelf
         - authentik-blueprint-miniflux
         - authentik-blueprint-linkding
         - authentik-blueprint-teslamate-grafana

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./httproute.yaml
   - ./referencegrant.yaml
   # per-app SSO blueprints (provider + application definitions)
+  - ./blueprints/audiobookshelf.yaml
   - ./blueprints/miniflux.yaml
   - ./blueprints/linkding.yaml
   - ./blueprints/teslamate-grafana.yaml


### PR DESCRIPTION
Wires Audiobookshelf into Authentik SSO, following the same blueprint-as-ExternalSecret pattern as romm/miniflux.

## What's in Git
- New blueprint `blueprints/audiobookshelf.yaml` — OAuth2 provider + application, delivered as an ESO-rendered Secret so the client secret stays in 1Password.
- Registered in the Authentik HelmRelease `blueprints.secrets` and the app kustomization.
- Bound to the `homelab` group in `access-control.yaml`.

Two redirect URIs are registered: `https://audiobookshelf.kalde.in/auth/openid/callback` (web) and `audiobookshelf://oauth` (the iOS/Android apps complete the flow on a custom scheme — without this, mobile SSO can't work).

`grant_types` is set explicitly (`authorization_code` + `refresh_token`) — blueprint-created providers default to an empty list on 2026.5+, which silently rejects the auth-code flow.

## What is NOT in Git — and why
Audiobookshelf has **no OIDC environment variables**. I checked the running image: the server only reads `authOpenID*` settings out of its SQLite database, so the app half of this config is DB state, not GitOps.

The following are applied via the ABS API and recorded here so they're recoverable if the config PVC is ever lost:

| Setting | Value |
|---|---|
| `authOpenIDIssuerURL` | `https://auth.kalde.in/application/o/audiobookshelf/` |
| `authOpenIDAuthorizationURL` | `https://auth.kalde.in/application/o/authorize/` |
| `authOpenIDTokenURL` | `https://auth.kalde.in/application/o/token/` |
| `authOpenIDUserInfoURL` | `https://auth.kalde.in/application/o/userinfo/` |
| `authOpenIDJwksURL` | `https://auth.kalde.in/application/o/audiobookshelf/jwks/` |
| `authOpenIDLogoutURL` | `https://auth.kalde.in/application/o/audiobookshelf/end-session/` |
| `authOpenIDMatchExistingBy` | `email` |
| `authOpenIDMobileRedirectURIs` | `audiobookshelf://oauth` |
| client id / secret | 1Password item `audiobookshelf` |

Local login stays **enabled** as a break-glass — if Authentik is down or the email match misbehaves, the root user can still get in.

## Rollout safety
The 1Password item and the ExternalSecret were created and confirmed syncing (`Ready=True`) **before** this merges. A blueprint Secret that can't sync makes the Authentik Helm upgrade fail and Flux roll back the entire Authentik release, so the secret has to exist first.

Post-merge the worker needs a restart — new blueprint secrets race the worker's startup discovery, and the access-control binding skips on first apply because the app doesn't exist yet when access-control applies alphabetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)