### PR TITLE
feat(authentik): exempt consolewiki pull URL from forward-auth

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -312,6 +312,10 @@ data:
           external_host: https://consolewiki.kalde.in
           internal_host: http://consolewiki.default.svc.cluster.local:80
           internal_host_ssl_validation: false
+          # Exempt this per-token pull URL from auth (like prometheus /federate):
+          # the sha256 token in the path is itself the credential, so a client
+          # can poll it without an Authentik session. UI stays gated.
+          skip_path_regex: ^/-/api/v1/pull/94608178e55edaff7bb85c4fe020bc334bd03c03381381e68f1d3dbd8074a627
           property_mappings:
             - !KeyOf mapping-otterwiki-headers
       - model: authentik_core.application


### PR DESCRIPTION
## Summary
Adds a `skip_path_regex` to the `consolewiki` proxy provider so the per-token pull endpoint bypasses the Authentik embedded proxy outpost, while the OtterWiki UI stays gated.

- **Path exempted:** `^/-/api/v1/pull/94608178e55edaff7bb85c4fe020bc334bd03c03381381e68f1d3dbd8074a627`
- The sha256 token in the path is itself the credential, so a client can poll this URL without an Authentik session.
- Same mechanism already used to exempt Prometheus's `/federate` from auth.

## Notes
- Regex is anchored to this specific token. To exempt any OtterWiki pull URL, switch to the prefix `^/-/api/v1/pull/`.
- Flux-managed blueprint; reconciles on next Flux sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)