### PR TITLE
feat(authentik): send email via Purelymail + password recovery flow

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/recovery-email.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/recovery-email.yaml
@@ -1,0 +1,205 @@
+---
+# Password recovery ("Forgot password?") via emailed reset link.
+#
+# Adapted from the stock example shipped in the authentik image at
+# /blueprints/example/flows-recovery-email-verification.yaml, which is
+# labelled instantiate=false. Copied here (rather than instantiating the
+# example by path) so the flow is explicit in Git and does not shift under
+# us when the image's example files change.
+#
+# The email stage uses `use_global_settings: true`, so SMTP comes from the
+# global AUTHENTIK_EMAIL__* config: host/port/TLS in the HelmRelease values,
+# username/password/from from the `authentik` 1Password item via the
+# authentik-secret ExternalSecret. No credentials live in this file.
+#
+# The final `authentik_brands.brand` entry is what actually surfaces the
+# "Forgot password?" link on the login page — without it the flow exists but
+# is unreachable.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-recovery-email
+  namespace: security
+data:
+  recovery-email.yaml: |
+    version: 1
+    metadata:
+      name: recovery-email
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - identifiers:
+          slug: default-recovery-flow
+        id: flow
+        model: authentik_flows.flow
+        state: present
+        attrs:
+          name: Default recovery flow
+          title: Reset your password
+          designation: recovery
+          authentication: require_unauthenticated
+
+      # ── prompts: the new password + confirmation ────────────────────
+      - identifiers:
+          name: default-recovery-field-password
+        id: prompt-field-password
+        model: authentik_stages_prompt.prompt
+        state: present
+        attrs:
+          field_key: password
+          label: Password
+          type: password
+          required: true
+          placeholder: Password
+          order: 0
+          placeholder_expression: false
+      - identifiers:
+          name: default-recovery-field-password-repeat
+        id: prompt-field-password-repeat
+        model: authentik_stages_prompt.prompt
+        state: present
+        attrs:
+          field_key: password_repeat
+          label: Password (repeat)
+          type: password
+          required: true
+          placeholder: Password (repeat)
+          order: 1
+          placeholder_expression: false
+
+      # Skips the identification stage when the flow is resumed from the
+      # emailed link (the user is already known at that point).
+      - identifiers:
+          name: default-recovery-skip-if-restored
+        id: default-recovery-skip-if-restored
+        model: authentik_policies_expression.expressionpolicy
+        state: present
+        attrs:
+          expression: |
+            return bool(request.context.get('is_restored', True))
+
+      # ── stages ──────────────────────────────────────────────────────
+      # use_global_settings=true -> SMTP from AUTHENTIK_EMAIL__* env; the
+      # host/port/from below are placeholders authentik ignores in that mode.
+      - identifiers:
+          name: default-recovery-email
+        id: default-recovery-email
+        model: authentik_stages_email.emailstage
+        state: present
+        attrs:
+          use_global_settings: true
+          host: localhost
+          port: 25
+          username: ""
+          use_tls: false
+          use_ssl: false
+          timeout: 10
+          from_address: system@authentik.local
+          token_expiry: minutes=30
+          subject: Reset your password
+          template: email/password_reset.html
+          activate_user_on_success: true
+          recovery_max_attempts: 5
+          recovery_cache_timeout: minutes=5
+      - identifiers:
+          name: default-recovery-user-write
+        id: default-recovery-user-write
+        model: authentik_stages_user_write.userwritestage
+        state: present
+        attrs:
+          user_creation_mode: never_create
+      - identifiers:
+          name: default-recovery-identification
+        id: default-recovery-identification
+        model: authentik_stages_identification.identificationstage
+        state: present
+        attrs:
+          user_fields:
+            - email
+            - username
+      - identifiers:
+          name: default-recovery-user-login
+        id: default-recovery-user-login
+        model: authentik_stages_user_login.userloginstage
+        state: present
+      - identifiers:
+          name: Change your password
+        id: stages-prompt-password
+        model: authentik_stages_prompt.promptstage
+        state: present
+        attrs:
+          fields:
+            - !KeyOf prompt-field-password
+            - !KeyOf prompt-field-password-repeat
+          validation_policies: []
+
+      # ── flow order: identify -> email link -> new password -> save ──
+      - identifiers:
+          target: !KeyOf flow
+          stage: !KeyOf default-recovery-identification
+          order: 10
+        model: authentik_flows.flowstagebinding
+        id: flow-binding-identification
+        attrs:
+          evaluate_on_plan: true
+          re_evaluate_policies: true
+          policy_engine_mode: any
+          invalid_response_action: retry
+      - identifiers:
+          target: !KeyOf flow
+          stage: !KeyOf default-recovery-email
+          order: 20
+        model: authentik_flows.flowstagebinding
+        id: flow-binding-email
+        attrs:
+          evaluate_on_plan: true
+          re_evaluate_policies: true
+          policy_engine_mode: any
+          invalid_response_action: retry
+      - identifiers:
+          target: !KeyOf flow
+          stage: !KeyOf stages-prompt-password
+          order: 30
+        model: authentik_flows.flowstagebinding
+        attrs:
+          evaluate_on_plan: true
+          re_evaluate_policies: false
+          policy_engine_mode: any
+          invalid_response_action: retry
+      - identifiers:
+          target: !KeyOf flow
+          stage: !KeyOf default-recovery-user-write
+          order: 40
+        model: authentik_flows.flowstagebinding
+        attrs:
+          evaluate_on_plan: true
+          re_evaluate_policies: false
+          policy_engine_mode: any
+          invalid_response_action: retry
+      - identifiers:
+          target: !KeyOf flow
+          stage: !KeyOf default-recovery-user-login
+          order: 100
+        model: authentik_flows.flowstagebinding
+        attrs:
+          evaluate_on_plan: true
+          re_evaluate_policies: false
+          policy_engine_mode: any
+          invalid_response_action: retry
+      - identifiers:
+          policy: !KeyOf default-recovery-skip-if-restored
+          target: !KeyOf flow-binding-identification
+          order: 0
+        model: authentik_policies.policybinding
+        attrs:
+          negate: false
+          enabled: true
+          timeout: 30
+
+      # ── surface "Forgot password?" on the login page ────────────────
+      - identifiers:
+          domain: authentik-default
+        model: authentik_brands.brand
+        state: present
+        attrs:
+          flow_recovery: !KeyOf flow

--- a/kubernetes/apps/security/authentik/app/externalsecret.yaml
+++ b/kubernetes/apps/security/authentik/app/externalsecret.yaml
@@ -21,6 +21,12 @@ spec:
         AUTHENTIK_BOOTSTRAP_PASSWORD: "{{ .AUTHENTIK_BOOTSTRAP_PASSWORD }}"
         AUTHENTIK_BOOTSTRAP_TOKEN: "{{ .AUTHENTIK_BOOTSTRAP_TOKEN }}"
         AUTHENTIK_BOOTSTRAP_EMAIL: "{{ .AUTHENTIK_BOOTSTRAP_EMAIL }}"
+        # outbound SMTP credentials (Purelymail). Host/port/TLS are set in the
+        # HelmRelease; only the secrets live here. Username is the full email
+        # address; password is a Purelymail app password if 2FA is enabled.
+        AUTHENTIK_EMAIL__USERNAME: "{{ .EMAIL_USERNAME }}"
+        AUTHENTIK_EMAIL__PASSWORD: "{{ .EMAIL_PASSWORD }}"
+        AUTHENTIK_EMAIL__FROM: "{{ .EMAIL_FROM }}"
         # database password (server + worker connect as the authentik role)
         AUTHENTIK_POSTGRESQL__PASSWORD: "{{ .POSTGRES_PASS }}"
         # postgres-init initContainer: creates the db + role using superuser creds

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -45,6 +45,19 @@ spec:
         user: authentik
       redis:
         host: authentik-redis-app.security.svc.cluster.local
+      # Outbound SMTP (Purelymail) — powers the password-recovery emails.
+      # Non-secret settings only; username/password/from come from the
+      # `authentik` 1Password item via authentik-secret (global.envFrom).
+      # These MUST stay here rather than in the secret: the chart renders
+      # values set here as explicit container `env`, which takes precedence
+      # over `envFrom` — so a use_tls set via the secret would be silently
+      # overridden by the chart's default of false.
+      email:
+        host: smtp.purelymail.com
+        port: 587
+        use_tls: true # 587 = STARTTLS (465 would be use_ssl instead)
+        use_ssl: false
+        timeout: 30
     # bundled Bitnami PostgreSQL subchart disabled — we use CloudNative-PG
     postgresql:
       enabled: false
@@ -60,6 +73,7 @@ spec:
         - authentik-blueprint-stirling-pdf
         - authentik-blueprint-romm
       configMaps:
+        - authentik-blueprint-recovery-email
         - authentik-blueprint-forward-auth
         - authentik-blueprint-access-control
     server:

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
   - ./blueprints/paperless.yaml
   - ./blueprints/stirling-pdf.yaml
   - ./blueprints/romm.yaml
+  # password recovery via emailed reset link (needs SMTP configured)
+  - ./blueprints/recovery-email.yaml
   # forward-auth (proxy outpost) apps — all in one deterministic blueprint
   - ./blueprints/forward-auth.yaml
   # declarative per-app access control (groups + application bindings)


### PR DESCRIPTION
## Why
Authentik couldn't send email at all — it was sitting on the chart's defaults (`EMAIL_HOST=localhost`, from `authentik@localhost`), with no SMTP server on localhost. There was also **no recovery flow**, no email stage, and nothing bound to the brand, so the login page had no "Forgot password?" link. That's fine when you're the only user with akadmin as break-glass, but not once other people have accounts.

## What
- **SMTP (Purelymail)**: `smtp.purelymail.com:587` with STARTTLS, per [their docs](https://support.purelymail.com/support/solutions/articles/159000430778-server-settings-imap-smtp-and-pop3).
- **Recovery flow**: identify → emailed reset link → new password → save → login.
- **Brand binding**: sets `flow_recovery`, which is what actually surfaces the "Forgot password?" link.

## Config split
Host/port/TLS are in the HelmRelease values; only `EMAIL_USERNAME` / `EMAIL_PASSWORD` / `EMAIL_FROM` come from the `authentik` 1Password item.

This split is deliberate: the chart renders `authentik.*` values as explicit container `env`, and `env` **takes precedence over `envFrom`**. A `use_tls` supplied via the secret would be silently overridden by the chart's default of `false` — i.e. an unencrypted connection that looks configured. Non-secret settings must live in values.

`EMAIL_FROM` is `Authentik <noreply@kalde.in>`. The display-name form works because the stage sets `use_global_settings: true`; authentik then skips the stage's `from_address` (an `EmailField`, which would reject a display name) and uses Django's `DEFAULT_FROM_EMAIL`, a plain string:

```python
if not stage.use_global_settings:
    message_object.from_email = stage.from_address
```

The `From:` header renders as `Authentik <noreply@kalde.in>` and smtplib puts the bare `<noreply@kalde.in>` in the SMTP envelope.

## Recovery flow provenance
Adapted from the example the image ships at `/blueprints/example/flows-recovery-email-verification.yaml` (labelled `instantiate: false`). Copied into Git rather than instantiated by path so an image upgrade can't shift it under us. Its email stage uses `use_global_settings: true`, so it inherits the SMTP config and holds no credentials — the `from_address`/`host` values in it are inert placeholders.

## Verification
The 1Password fields were added first and `ExternalSecret/authentik` reports `Ready=True | secret synced` with all keys present (`AUTHENTIK_SECRET_KEY` intact). Post-merge I'll confirm against what Flux actually reconciles, and send a real test email rather than trust the config alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)