### PR TITLE
chore(consolewiki): disable Flux prune on the data PVC

### DIFF
--- a/kubernetes/apps/default/consolewiki/app/config-pvc.yaml
+++ b/kubernetes/apps/default/consolewiki/app/config-pvc.yaml
@@ -4,6 +4,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: consolewiki-data-v1
   namespace: default
+  annotations:
+    # Keeps Flux from garbage-collecting this claim when the owning
+    # Kustomization is renamed (longhorn reclaimPolicy is Delete, so a prune
+    # would destroy the wiki data). Must land before the rename commit.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
Preparation for renaming `consolewiki` -> `wiki`. This is step 1 of 2 and must reconcile before the rename lands.

## Why this is separate

The rename moves the PVC from Kustomization `cluster-apps-consolewiki` to `cluster-apps-wiki`. Deleting the old Kustomization garbage-collects its inventory, and the `longhorn` StorageClass has `reclaimPolicy: Delete` — so a prune would destroy the wiki data.

Doing both in one commit would rely on Flux applying the new Kustomization before pruning the old one. That ordering isn't guaranteed, and the downside is irreversible.

With `kustomize.toolkit.fluxcd.io/prune: disabled` in place first, the PVC survives the transition and the new Kustomization adopts it by name.

## Verify after merge

```
kubectl get pvc consolewiki-data-v1 -n default -o jsonpath='{.metadata.annotations}'
```

Step 2 (the actual rename) should not be merged until that annotation is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)