### PR TITLE
feat(default): audiobook ingest pipeline (m4b-convert + beets)

### DIFF
--- a/kubernetes/apps/default/beets/app/config-pvc.yaml
+++ b/kubernetes/apps/default/beets/app/config-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: beets-config-v1
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/kubernetes/apps/default/beets/app/configmap.yaml
+++ b/kubernetes/apps/default/beets/app/configmap.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: beets-config
+  namespace: default
+data:
+  # BEETSDIR points here (read-only). The mutable bits — library.db, the
+  # import log — are written to /config, which is Longhorn, NOT NFS:
+  # beets' library is SQLite, same constraint as audiobookshelf's.
+  config.yaml: |
+    directory: /audiobooks
+    library: /config/library.db
+    statefile: /config/state.pickle
+
+    plugins: audible fromfilename filetote
+
+    asciify_paths: yes
+    art_filename: cover
+
+    import:
+      # /input entries are hardlinks to files transmission is still seeding.
+      # /input (192.168.10.101) and /audiobooks (192.168.10.3) are different
+      # filesystems, so "move" is always copy-then-unlink: the destination is
+      # a fresh inode that beets tags, and only the ingest *name* is removed.
+      # The seeding data is never touched.
+      #
+      # If /input and /audiobooks ever land on the same filesystem, move
+      # becomes a rename and `write: yes` would retag the seeded inode in
+      # place, corrupting the torrent. Switch to `copy: yes` if that changes.
+      copy: no
+      move: yes
+      write: yes
+      # Anything beets can't match confidently is left in /input for you to
+      # deal with by hand, rather than filed under a wrong author.
+      quiet_fallback: skip
+      duplicate_action: skip
+      log: /config/import.log
+
+    audible:
+      fetch_art: yes
+      match_chapters: yes
+      # Negative-ish weight makes Audible matches win over MusicBrainz.
+      source_weight: 0.0
+      region: us
+
+    # Carry the sidecar files beets-audible generates into the library so
+    # audiobookshelf picks up metadata without re-matching every book.
+    filetote:
+      extensions: .opf .jpg .png .cue
+      filenames: cover.jpg desc.txt reader.txt metadata.opf
+      pairing:
+        enabled: no
+
+    paths:
+      default: $albumartist/$album%aunique{}/$track - $title
+      singleton: $albumartist/$album%aunique{}/$title
+      comp: $albumartist/$album%aunique{}/$track - $title

--- a/kubernetes/apps/default/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/default/beets/app/helmrelease.yaml
@@ -1,0 +1,95 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app beets
+  namespace: default
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      beets:
+        type: cronjob
+        cronjob:
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 60
+          # A large import can outrun the interval; Forbid above keeps two
+          # beets processes off the one SQLite library. Offset ten minutes
+          # behind m4b-convert.
+          schedule: "*/15 * * * *"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gtronset/beets-audiobooks
+              tag: 2.2.0
+            # The image is linuxserver-based, so its entrypoint is the s6
+            # supervisor (/init) and never exits. Invoke beet directly —
+            # PUID/PGID setup is replaced by the pod securityContext below.
+            command: ["beet"]
+            args: ["import", "--quiet", "/input"]
+            env:
+              TZ: America/Chicago
+              BEETSDIR: /beets
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+            restartPolicy: Never
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1024
+            runAsGroup: 100
+            fsGroup: 100
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      beets:
+        enabled: false
+
+    persistence:
+      # SQLite library + import log — keep it off NFS.
+      config:
+        enabled: true
+        existingClaim: beets-config-v1
+        globalMounts:
+          - path: /config
+      beets-config:
+        enabled: true
+        type: configMap
+        name: beets-config
+        globalMounts:
+          - path: /beets
+      # Output of the m4b-convert cronjob, which is fed in turn by the
+      # transmission host's script-torrent-done hook. Everything here is
+      # already a single M4B.
+      input:
+        enabled: true
+        type: nfs
+        server: 192.168.10.101
+        path: /downloads/ingest/converted
+        globalMounts:
+          - path: /input
+      audiobooks:
+        enabled: true
+        type: nfs
+        server: 192.168.10.3
+        path: /volume1/share2/audiobooks
+        globalMounts:
+          - path: /audiobooks

--- a/kubernetes/apps/default/beets/app/kustomization.yaml
+++ b/kubernetes/apps/default/beets/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./config-pvc.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/default/beets/app/ocirepository.yaml
+++ b/kubernetes/apps/default/beets/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: beets
+  namespace: default
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/beets/ks.yaml
+++ b/kubernetes/apps/default/beets/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-beets
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/default/beets/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../components/common
 resources:
   - ./audiobookshelf/ks.yaml
+  - ./beets/ks.yaml
   - ./changedetection/ks.yaml
   - ./collabora/ks.yaml
   - ./wiki/ks.yaml
@@ -21,6 +22,7 @@ resources:
   - ./kometa/ks.yaml
   - ./lease-inventory/ks.yaml
   - ./linkding/ks.yaml
+  - ./m4b-convert/ks.yaml
   #- ./longhorn/ks.yaml
   - ./mealie/ks.yaml
   - ./miniflux/ks.yaml

--- a/kubernetes/apps/default/m4b-convert/app/configmap.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/configmap.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: m4b-convert-script
+  namespace: default
+data:
+  convert.sh: |
+    #!/bin/sh
+    # Multi-file MP3 audiobooks -> single chapterized M4B.
+    #
+    # /input  entries are hardlinks to data transmission is still seeding, so
+    #         this NEVER writes into them; it only reads and, on success,
+    #         unlinks the ingest name. The seeded inode survives.
+    # /output is staged as .<name>.part and renamed into place, so the beets
+    #         cronjob never sees a partially-written book.
+    set -eu
+
+    IN=/input
+    OUT=/output
+    FAILED=/failed
+
+    BITRATE=${BITRATE:-96k}
+    SAMPLERATE=${SAMPLERATE:-22050}
+    CHANNELS=${CHANNELS:-1}
+    JOBS=${JOBS:-4}
+
+    log() { echo "[$(date -Is)] $*"; }
+
+    mkdir -p "$OUT" "$FAILED"
+
+    has_ext() {
+      find "$1" -maxdepth 2 -type f -iname "*.$2" -print 2>/dev/null | head -n1 | grep -q .
+    }
+
+    publish() {
+      # publish <work-dir> <name> — atomic rename into $OUT
+      rm -rf "${OUT:?}/$2"
+      mv "$1" "$OUT/$2"
+    }
+
+    fail() {
+      # fail <src> <name>
+      log "FAILED: $2"
+      rm -rf "${FAILED:?}/$2"
+      mv "$1" "$FAILED/$2"
+    }
+
+    convert() {
+      src=$1
+      name=$2
+      work="$OUT/.$name.part"
+      rm -rf "$work"
+      mkdir -p "$work"
+      log "converting: $name (bitrate=$BITRATE rate=$SAMPLERATE ch=$CHANNELS)"
+      if m4b-tool merge "$src" \
+          --output-file "$work/$name.m4b" \
+          --jobs "$JOBS" \
+          --audio-bitrate "$BITRATE" \
+          --audio-samplerate "$SAMPLERATE" \
+          --audio-channels "$CHANNELS" \
+          --use-filenames-as-chapters \
+          --no-cache \
+          --force; then
+        # Carry sidecars through for beets-audible / filetote to pick up.
+        if [ -d "$src" ]; then
+          for extra in cover.jpg cover.png folder.jpg metadata.opf desc.txt reader.txt; do
+            [ -f "$src/$extra" ] && cp "$src/$extra" "$work/" || true
+          done
+        fi
+        publish "$work" "$name"
+        rm -rf "$src"
+        log "converted: $name"
+      else
+        rm -rf "$work"
+        fail "$src" "$name"
+      fi
+    }
+
+    passthrough() {
+      # Already M4B — no transcode. Same filesystem, so this is a rename that
+      # preserves the hardlink; nothing is copied.
+      src=$1
+      name=$2
+      work="$OUT/.$name.part"
+      rm -rf "$work"
+      if [ -d "$src" ]; then
+        mv "$src" "$work"
+      else
+        mkdir -p "$work"
+        mv "$src" "$work/"
+      fi
+      publish "$work" "$name"
+      log "passthrough: $name"
+    }
+
+    found=0
+    for src in "$IN"/*; do
+      [ -e "$src" ] || continue
+      name=$(basename "$src")
+      case "$name" in .*) continue ;; esac
+      found=$((found + 1))
+
+      if [ -f "$src" ]; then
+        case "$name" in
+          *.m4b|*.M4B|*.m4a|*.M4A) passthrough "$src" "${name%.*}" ;;
+          *.mp3|*.MP3)             convert "$src" "${name%.*}" ;;
+          *)                       fail "$src" "$name" ;;
+        esac
+      elif has_ext "$src" mp3; then
+        convert "$src" "$name"
+      elif has_ext "$src" m4b || has_ext "$src" m4a; then
+        passthrough "$src" "$name"
+      else
+        log "no audio found in: $name"
+        fail "$src" "$name"
+      fi
+    done
+
+    log "done, $found item(s) examined"

--- a/kubernetes/apps/default/m4b-convert/app/helmrelease.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/helmrelease.yaml
@@ -1,0 +1,111 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app m4b-convert
+  namespace: default
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      m4b-convert:
+        type: cronjob
+        cronjob:
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 60
+          # Runs ten minutes ahead of the beets import at */15, so a book
+          # converted this cycle is picked up on the next one.
+          schedule: "5,20,35,50 * * * *"
+        containers:
+          app:
+            image:
+              repository: docker.io/sandreas/m4b-tool
+              tag: 0.5.2
+            # Image entrypoint is m4b-tool itself; replace it with the driver
+            # script, which invokes m4b-tool per book.
+            command: ["/bin/sh"]
+            args: ["/scripts/convert.sh"]
+            env:
+              TZ: America/Chicago
+              M4BTOOL_TMP_DIR: /tmp/m4b-tool
+              # Spoken-word defaults. Bump BITRATE / set CHANNELS=2 if you
+              # care about a music-heavy production.
+              BITRATE: 96k
+              SAMPLERATE: "22050"
+              CHANNELS: "1"
+              JOBS: "4"
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                cpu: "4"
+                memory: 4Gi
+            restartPolicy: Never
+        pod:
+          # Transcoding on a Pi is punishing; pin to the amd64 control planes
+          # (schedulable per talos/patches/controller/cluster.yaml).
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1024
+            runAsGroup: 100
+            fsGroup: 100
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      m4b-convert:
+        enabled: false
+
+    persistence:
+      scripts:
+        enabled: true
+        type: configMap
+        name: m4b-convert-script
+        defaultMode: 0555
+        globalMounts:
+          - path: /scripts
+      # Raw output of the transmission script-torrent-done hook.
+      input:
+        enabled: true
+        type: nfs
+        server: 192.168.10.101
+        path: /downloads/ingest/audiobooks
+        globalMounts:
+          - path: /input
+      # Handoff to the beets cronjob.
+      output:
+        enabled: true
+        type: nfs
+        server: 192.168.10.101
+        path: /downloads/ingest/converted
+        globalMounts:
+          - path: /output
+      failed:
+        enabled: true
+        type: nfs
+        server: 192.168.10.101
+        path: /downloads/ingest/failed
+        globalMounts:
+          - path: /failed
+      # m4b-tool needs a writable scratch dir for its intermediate files.
+      tmp:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/default/m4b-convert/app/kustomization.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/default/m4b-convert/app/ocirepository.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: m4b-convert
+  namespace: default
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/m4b-convert/ks.yaml
+++ b/kubernetes/apps/default/m4b-convert/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-m4b-convert
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/default/m4b-convert/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/m4b-convert/transmission-ingest.sh
+++ b/kubernetes/apps/default/m4b-convert/transmission-ingest.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Transmission script-torrent-done hook.
+# Stages completed audiobook torrents into an ingest dir for beets.
+# Install on 192.168.10.101, chmod 0755, owned by the transmission user.
+set -euo pipefail
+
+INGEST=/downloads/ingest/audiobooks
+LOG=/var/log/transmission-ingest.log
+INGEST_GID=100   # must match the beets pod's runAsGroup
+
+log() { echo "$(date -Is) $*" >>"$LOG"; }
+
+# Transmission 4.x only. On 3.x there is no label env var — filter on
+# TR_TORRENT_DIR with a per-torrent download location instead.
+case "${TR_TORRENT_LABELS:-}" in
+  *audiobook*) ;;
+  *) exit 0 ;;
+esac
+
+src="${TR_TORRENT_DIR}/${TR_TORRENT_NAME}"
+dst="${INGEST}/${TR_TORRENT_NAME}"
+
+mkdir -p "$INGEST"
+
+if [ -e "$dst" ]; then
+  log "skip, already staged: ${TR_TORRENT_NAME}"
+  exit 0
+fi
+
+# Stage under .part and rename into place. Rename within one directory is
+# atomic, so the beets cronjob never sees a half-written tree.
+stage() {
+  if cp -al "$src" "$dst.part" 2>/dev/null; then
+    log "linked: ${TR_TORRENT_NAME}"
+  else
+    # Different filesystem — fall back to a real copy.
+    rm -rf "$dst.part"
+    cp -r "$src" "$dst.part"
+    log "copied: ${TR_TORRENT_NAME}"
+  fi
+  # beets runs as gid 100 and needs to unlink these after import.
+  chgrp -R "$INGEST_GID" "$dst.part" 2>/dev/null || true
+  chmod -R g+rwX "$dst.part"
+  mv "$dst.part" "$dst"
+}
+
+# Hardlinks are instant; a cross-filesystem copy is not, and transmission
+# blocks on this script. Background the slow path so the daemon stays
+# responsive.
+if [ "$(stat -c %d "$src")" = "$(stat -c %d "$INGEST")" ]; then
+  stage
+else
+  stage &
+fi


### PR DESCRIPTION
## What

Adds two CronJob apps that turn completed audiobook downloads into an organized, chapterized Audiobookshelf library, with the download client hook that feeds them.

```
transmission hook  ──►  m4b-convert  ──►  beets  ──►  192.168.10.3:/volume1/share2/audiobooks
(.101, off-cluster)     :05/:20/:35/:50   :00/:15/:30/:45      (the Audiobookshelf library)
```

## Stages

- **`m4b-convert`** ([`sandreas/m4b-tool`](https://github.com/sandreas/m4b-tool)) — merges multi-file MP3 books into a single chapterized M4B via `--use-filenames-as-chapters`; passes existing M4B/M4A through without transcoding; quarantines anything with no audio to a `failed/` dir. Pinned to the amd64 control planes (`nodeSelector: kubernetes.io/arch: amd64`) because transcoding a full book on a Pi is impractical. Spoken-word encode defaults (96k / 22050Hz / mono), overridable via env.
- **`beets`** ([`gtronset/beets-audiobooks`](https://github.com/gtronset/beets-audiobooks)) — matches against Audible via the `audible` plugin, organizes into `Author/Book`, and moves into the library. SQLite library lives on Longhorn, off NFS (same constraint as audiobookshelf). `duplicate_action: skip` + `quiet_fallback: skip` so ambiguous books are left for manual review rather than misfiled.

Each stage stages its output under a `.part` name and renames atomically, so the next stage never picks up a partially-written book. `beets` consumes `m4b-convert`'s output (`/downloads/ingest/converted`), not the raw ingest dir.

## Off-cluster piece

`m4b-convert/transmission-ingest.sh` is the `script-torrent-done` hook. It hardlinks torrents labeled `audiobook` into the ingest dir (instant, no extra disk, seeding untouched). Versioned in-repo so the whole pipeline is in one place, but it runs on the transmission host (`192.168.10.101`), **not** in the cluster — installing it is a manual step.

## Manual steps before this works end to end

- [ ] Create `audiobooks/`, `converted/`, `failed/` under `/downloads/ingest/` on `.101`, writable by uid 1024 / gid 100
- [ ] Install `transmission-ingest.sh`, `chmod 0755`, wire it into `settings.json` (with the daemon stopped) and confirm transmission is 4.x (`TR_TORRENT_LABELS`)
- [ ] Label audiobook torrents `audiobook`
- [ ] Smoke-test with `kubectl create job --from=cronjob/m4b-convert` before trusting the schedule

## Validation

`kustomize build` (both apps + parent) and `helm template` against app-template 5.0.1 pass; `convert.sh` and the hook are `sh -n`/`bash -n` clean.

## Note

m4b-tool derives chapters from file boundaries — a book that's 3 giant MP3s or has junk filenames converts, but with poor chapter data, and won't land in `failed/`. Those need a manual look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)