### PR TITLE
m4b-convert: single ingest mount + merge multi-file m4b folders

### DIFF
--- a/kubernetes/apps/default/m4b-convert/app/configmap.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/configmap.yaml
@@ -39,6 +39,10 @@ data:
       find "$1" -maxdepth 2 -type f -iname "*.$2" -print 2>/dev/null | head -n1 | grep -q .
     }
 
+    count_m4b() {
+      find "$1" -maxdepth 2 -type f \( -iname '*.m4b' -o -iname '*.m4a' \) 2>/dev/null | wc -l | tr -d ' '
+    }
+
     publish() {
       # publish <work-dir> <name> — atomic rename into $OUT
       rm -rf "${OUT:?}/$2"
@@ -52,22 +56,38 @@ data:
       mv "$1" "$FAILED/$2"
     }
 
-    convert() {
+    # do_merge <src> <name> <mode>
+    #   mode=transcode  MP3 (and friends) -> re-encoded AAC with the spoken-word
+    #                   settings; filenames become chapter titles.
+    #   mode=copy       multiple existing m4b/m4a parts -> single m4b via a
+    #                   lossless stream copy (--no-conversion). No chapter
+    #                   override, so embedded chapter marks are preserved;
+    #                   m4b-tool falls back to per-file chapters when there
+    #                   are none.
+    do_merge() {
       src=$1
       name=$2
+      mode=$3
       work="$OUT/.$name.part"
       rm -rf "$work"
       mkdir -p "$work"
-      log "converting: $name (bitrate=$BITRATE rate=$SAMPLERATE ch=$CHANNELS)"
+      case "$mode" in
+        transcode)
+          log "converting (transcode): $name (bitrate=$BITRATE rate=$SAMPLERATE ch=$CHANNELS)"
+          set -- --audio-bitrate "$BITRATE" --audio-samplerate "$SAMPLERATE" \
+                 --audio-channels "$CHANNELS" --use-filenames-as-chapters
+          ;;
+        copy)
+          log "merging (lossless): $name"
+          set -- --no-conversion
+          ;;
+      esac
       if m4b-tool merge "$src" \
           --output-file "$work/$name.m4b" \
           --jobs "$JOBS" \
-          --audio-bitrate "$BITRATE" \
-          --audio-samplerate "$SAMPLERATE" \
-          --audio-channels "$CHANNELS" \
-          --use-filenames-as-chapters \
           --no-cache \
-          --force; then
+          --force \
+          "$@"; then
         # Carry sidecars through for beets-audible / filetote to pick up.
         if [ -d "$src" ]; then
           for extra in cover.jpg cover.png folder.jpg metadata.opf desc.txt reader.txt; do
@@ -76,7 +96,7 @@ data:
         fi
         publish "$work" "$name"
         rm -rf "$src"
-        log "converted: $name"
+        log "done: $name"
       else
         rm -rf "$work"
         fail "$src" "$name"
@@ -84,8 +104,8 @@ data:
     }
 
     passthrough() {
-      # Already M4B — no transcode. Same filesystem, so this is a rename that
-      # preserves the hardlink; nothing is copied.
+      # A single, already-final M4B — nothing to merge or transcode. Same
+      # filesystem, so this is a rename that preserves the hardlink.
       src=$1
       name=$2
       work="$OUT/.$name.part"
@@ -110,13 +130,19 @@ data:
       if [ -f "$src" ]; then
         case "$name" in
           *.m4b|*.M4B|*.m4a|*.M4A) passthrough "$src" "${name%.*}" ;;
-          *.mp3|*.MP3)             convert "$src" "${name%.*}" ;;
+          *.mp3|*.MP3)             do_merge "$src" "${name%.*}" transcode ;;
           *)                       fail "$src" "$name" ;;
         esac
       elif has_ext "$src" mp3; then
-        convert "$src" "$name"
+        do_merge "$src" "$name" transcode
       elif has_ext "$src" m4b || has_ext "$src" m4a; then
-        passthrough "$src" "$name"
+        # One m4b in the folder: already final, just move it. Multiple parts:
+        # merge them losslessly into a single chapterized m4b.
+        if [ "$(count_m4b "$src")" -gt 1 ]; then
+          do_merge "$src" "$name" copy
+        else
+          passthrough "$src" "$name"
+        fi
       else
         log "no audio found in: $name"
         fail "$src" "$name"

--- a/kubernetes/apps/default/m4b-convert/app/configmap.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/configmap.yaml
@@ -9,16 +9,22 @@ data:
     #!/bin/sh
     # Multi-file MP3 audiobooks -> single chapterized M4B.
     #
-    # /input  entries are hardlinks to data transmission is still seeding, so
-    #         this NEVER writes into them; it only reads and, on success,
-    #         unlinks the ingest name. The seeded inode survives.
-    # /output is staged as .<name>.part and renamed into place, so the beets
-    #         cronjob never sees a partially-written book.
+    # All three dirs are subdirs of ONE NFS mount (/ingest), so every move
+    # between them is a true rename within a single filesystem: atomic, no
+    # copy, and it preserves the hardlink back to the seeding torrent.
+    # Mounting them as separate NFS shares would make each move a
+    # cross-device copy+chown, which fails as non-root on a squashed export.
+    #
+    # $IN entries are hardlinks to data transmission is still seeding, so this
+    # NEVER writes into them; it only reads and, on success, renames the
+    # ingest name away. The seeded inode survives.
+    # $OUT is staged as .<name>.part and renamed into place, so the beets
+    # cronjob never sees a partially-written book.
     set -eu
 
-    IN=/input
-    OUT=/output
-    FAILED=/failed
+    IN=/ingest/audiobooks
+    OUT=/ingest/converted
+    FAILED=/ingest/failed
 
     BITRATE=${BITRATE:-96k}
     SAMPLERATE=${SAMPLERATE:-22050}
@@ -27,7 +33,7 @@ data:
 
     log() { echo "[$(date -Is)] $*"; }
 
-    mkdir -p "$OUT" "$FAILED"
+    mkdir -p "$IN" "$OUT" "$FAILED"
 
     has_ext() {
       find "$1" -maxdepth 2 -type f -iname "*.$2" -print 2>/dev/null | head -n1 | grep -q .

--- a/kubernetes/apps/default/m4b-convert/app/helmrelease.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/helmrelease.yaml
@@ -80,29 +80,16 @@ spec:
         defaultMode: 0555
         globalMounts:
           - path: /scripts
-      # Raw output of the transmission script-torrent-done hook.
-      input:
+      # One mount of the whole ingest tree so audiobooks/ (hook output),
+      # converted/ (beets input) and failed/ share a single filesystem —
+      # moves between them are atomic renames, not cross-device copies.
+      ingest:
         enabled: true
         type: nfs
         server: 192.168.10.101
-        path: /downloads/ingest/audiobooks
+        path: /downloads/ingest
         globalMounts:
-          - path: /input
-      # Handoff to the beets cronjob.
-      output:
-        enabled: true
-        type: nfs
-        server: 192.168.10.101
-        path: /downloads/ingest/converted
-        globalMounts:
-          - path: /output
-      failed:
-        enabled: true
-        type: nfs
-        server: 192.168.10.101
-        path: /downloads/ingest/failed
-        globalMounts:
-          - path: /failed
+          - path: /ingest
       # m4b-tool needs a writable scratch dir for its intermediate files.
       tmp:
         enabled: true


### PR DESCRIPTION
Follow-up to #476. Two related changes to the m4b-convert cronjob (the
second stacked on the first since they touch the same script).

## 1. fix: single ingest mount to avoid cross-device mv

`audiobooks/`, `converted/` and `failed/` were three **separate** NFS mounts. Each is a distinct device to the kernel, so a `mv` between them is a recursive copy-then-`chown`, not a rename. As the non-root pod uid on a root-squashed export the `chown` is denied:

```
mv: can't preserve ownership of '/output/.<book>.part/NN - Chapter NN.m4b': Operation not permitted
```

one line per file, and it can non-zero-exit under `set -e`, wedging the book as a leftover `.part`.

**Fix:** mount the parent `/downloads/ingest` once at `/ingest`, use subdirs. Every hop is now a true intra-filesystem rename — atomic, no copy, no `chown`, hardlink to the seeding torrent preserved.

## 2. feat: merge multi-file m4b folders into one chapterized m4b

A folder of several `.m4b`/`.m4a` parts (e.g. per-chapter split books) was passed through as-is, leaving N separate files in the library. Now they're merged into a single m4b.

- `convert()` → `do_merge <src> <name> <mode>`:
  - `mode=copy` — `m4b-tool --no-conversion`, a **lossless stream copy** (plain `merge` re-encodes by default). Used for multi-part m4b/m4a folders.
  - `mode=transcode` — unchanged MP3 re-encode with the spoken-word settings.
- `copy` mode omits `--use-filenames-as-chapters`, so embedded chapter marks in multi-chapter parts survive; m4b-tool falls back to per-file chapters when there are none.
- A single m4b — a loose file, or a folder with exactly one — still passes through untouched (`count_m4b`).

### Dispatch matrix

| Source | Action |
|---|---|
| loose `.m4b`/`.m4a` file | passthrough (rename) |
| folder, 1 × m4b/m4a | passthrough (rename) |
| folder, ≥2 × m4b/m4a | **lossless merge** → 1 m4b |
| loose `.mp3` / folder of mp3 | transcode → 1 m4b |
| no audio | quarantine to `failed/` |

## Validation

`kustomize build` (app + parent) and `sh -n` pass. Dispatch + flag routing exercised against a mock `m4b-tool`: multi-part→`--no-conversion`, mp3→transcode+filename-chapters, single→passthrough; nothing stranded.

## Manual cleanup on the transmission host

- [ ] Remove any leftover `/downloads/ingest/converted/.*.part/` dirs from the earlier failed run; the source in `audiobooks/` will be reprocessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)