### PR TITLE
fix(m4b-convert): local scratch + shared lock

### DIFF
--- a/kubernetes/apps/default/m4b-convert/app/configmap.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/configmap.yaml
@@ -31,9 +31,30 @@ data:
     CHANNELS=${CHANNELS:-1}
     JOBS=${JOBS:-4}
 
+    # m4b-tool builds output here (local emptyDir); the finished book is then
+    # relocated to NFS. Both must share one filesystem with M4BTOOL_TMP_DIR so
+    # m4b-tool's internal tmp->output rename() stays intra-device.
+    STAGE=/tmp/staging
+
     log() { echo "[$(date -Is)] $*"; }
 
-    mkdir -p "$IN" "$OUT" "$FAILED"
+    mkdir -p "$IN" "$OUT" "$FAILED" "$STAGE"
+
+    # concurrencyPolicy:Forbid only serializes *scheduled* runs; a manually
+    # created Job (e.g. a smoke test) can still overlap a scheduled tick, and
+    # two pods sharing these NFS dirs rm -rf each other's work. Take a shared
+    # lock (mkdir is atomic on NFS) so any second run bails cleanly. Reclaim a
+    # lock older than 180m in case a holder died without releasing it.
+    LOCK=/ingest/.m4b-convert.lock
+    if [ -d "$LOCK" ] && [ -z "$(find "$LOCK" -maxdepth 0 -mmin -180 2>/dev/null)" ]; then
+      log "clearing stale lock"
+      rmdir "$LOCK" 2>/dev/null || true
+    fi
+    if ! mkdir "$LOCK" 2>/dev/null; then
+      log "another m4b-convert run is active; exiting"
+      exit 0
+    fi
+    trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT INT TERM
 
     has_ext() {
       find "$1" -maxdepth 2 -type f -iname "*.$2" -print 2>/dev/null | head -n1 | grep -q .
@@ -68,9 +89,10 @@ data:
       src=$1
       name=$2
       mode=$3
-      work="$OUT/.$name.part"
-      rm -rf "$work"
-      mkdir -p "$work"
+      work="$OUT/.$name.part"        # NFS, hidden so beets ignores it
+      stage="$STAGE/$name"           # local scratch, same FS as m4b-tool tmp
+      rm -rf "$work" "$stage"
+      mkdir -p "$stage"
       case "$mode" in
         transcode)
           log "converting (transcode): $name (bitrate=$BITRATE rate=$SAMPLERATE ch=$CHANNELS)"
@@ -82,8 +104,10 @@ data:
           set -- --no-conversion
           ;;
       esac
+      # Build entirely on local scratch: m4b-tool's tmp->output rename() cannot
+      # cross from the emptyDir onto NFS, so the output must land locally too.
       if m4b-tool merge "$src" \
-          --output-file "$work/$name.m4b" \
+          --output-file "$stage/$name.m4b" \
           --jobs "$JOBS" \
           --no-cache \
           --force \
@@ -91,14 +115,25 @@ data:
         # Carry sidecars through for beets-audible / filetote to pick up.
         if [ -d "$src" ]; then
           for extra in cover.jpg cover.png folder.jpg metadata.opf desc.txt reader.txt; do
-            [ -f "$src/$extra" ] && cp "$src/$extra" "$work/" || true
+            [ -f "$src/$extra" ] && cp "$src/$extra" "$stage/" || true
           done
         fi
-        publish "$work" "$name"
-        rm -rf "$src"
-        log "done: $name"
+        # Relocate the finished book to NFS. It is a freshly built inode, so a
+        # copy is correct (nothing to hardlink); cp without -p avoids the chown
+        # a root-squashed export would reject. beets skips the hidden .part
+        # dir until publish() reveals it via an atomic NFS->NFS rename.
+        mkdir -p "$work"
+        if cp -r "$stage/." "$work/"; then
+          rm -rf "$stage"
+          publish "$work" "$name"
+          rm -rf "$src"
+          log "done: $name"
+        else
+          rm -rf "$work" "$stage"
+          fail "$src" "$name"
+        fi
       else
-        rm -rf "$work"
+        rm -rf "$work" "$stage"
         fail "$src" "$name"
       fi
     }


### PR DESCRIPTION
Follow-up to #477 (which merged before this fix was pushed). Fixes two failures observed on the same book in the live cronjob.

## 1. Cross-device rename

m4b-tool builds its output in `M4BTOOL_TMP_DIR` (`/tmp`, the emptyDir) and then `rename()`s it to `--output-file`. With `--output-file` pointing at NFS, that's a cross-filesystem rename, which fails:

```
PHP Warning: rename(/tmp/m4b-tool/tmp_<book>.m4b, /ingest/converted/.<book>.part/<book>.m4b): ...
Could not rename output file ...
```

**Fix:** m4b-tool now writes entirely to a local scratch dir (same filesystem as its tmp), and the script relocates only the finished `.m4b` onto NFS. A converted book is a freshly built inode, so a copy is correct here — nothing to hardlink — and `cp` without `-p` avoids the `chown` a root-squashed export rejects.

## 2. Concurrent runs colliding

`concurrencyPolicy: Forbid` only serializes the CronJob controller's **scheduled** runs. A manually-created Job (e.g. `kubectl create job --from=cronjob/m4b-convert` for a smoke test) runs independently and can overlap a scheduled tick. Two pods then `rm -rf` each other's `.part` dir and consume the same source — the ENOENT `No such file or directory` seen on both the output rename and the source `mv`.

**Fix:** a shared `mkdir` lock on the NFS mount (atomic across pods) with a 180-minute stale-lock reclaim. Any second run — scheduled or manual — logs `another m4b-convert run is active` and exits cleanly.

## Validation

`kustomize build` (parent) and `sh -n` pass. Exercised against a mock `m4b-tool`: normal run relocates output to `converted/` and consumes the source; a second run with the lock held bails; per-mode flags (`--no-conversion` vs transcode) intact.

## Cleanup on the transmission host (from the earlier collision)

- [ ] Check `/ingest/converted/` — the winning pod likely finished `East of Eden` there.
- [ ] Remove any stray `/ingest/converted/.*.part/` dirs.
- [ ] If `East of Eden` is in neither `converted/` nor `failed/`, its source was consumed without publishing — restage it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)