### PR TITLE
fix(beets): align audible config so books stop skipping

### DIFF
--- a/kubernetes/apps/default/beets/app/configmap.yaml
+++ b/kubernetes/apps/default/beets/app/configmap.yaml
@@ -13,46 +13,64 @@ data:
     library: /config/library.db
     statefile: /config/state.pickle
 
-    plugins: audible fromfilename filetote
+    # 'edit' from the plugin's recommended list is interactive-only and omitted
+    # (this runs headless). 'scrub' clears the messy source tags so the audible
+    # plugin can write clean ones; 'filetote' carries source-side sidecars
+    # (metadata.yml, cover) into the library.
+    plugins: audible fromfilename scrub filetote
 
     asciify_paths: yes
     art_filename: cover
 
+    # beets-audible REQUIRES MusicBrainz disabled: it has no audiobooks, and
+    # its noise is what dropped Audible matches below the quiet auto-apply bar,
+    # so everything fell through to quiet_fallback: skip.
+    musicbrainz:
+      enabled: no
+
     import:
       # /input entries are hardlinks to files transmission is still seeding.
       # /input (192.168.10.101) and /audiobooks (192.168.10.3) are different
-      # filesystems, so "move" is always copy-then-unlink: the destination is
-      # a fresh inode that beets tags, and only the ingest *name* is removed.
-      # The seeding data is never touched.
-      #
-      # If /input and /audiobooks ever land on the same filesystem, move
-      # becomes a rename and `write: yes` would retag the seeded inode in
-      # place, corrupting the torrent. Switch to `copy: yes` if that changes.
+      # filesystems, so "move" is copy-then-unlink: beets tags a fresh inode at
+      # the destination and only unlinks the ingest name. Seeding is untouched.
       copy: no
       move: yes
       write: yes
-      # Anything beets can't match confidently is left in /input for you to
-      # deal with by hand, rather than filed under a wrong author.
+      # No human at a cronjob: a non-strong match can't be confirmed, so skip
+      # it (left in /input) rather than misfile under a wrong author.
       quiet_fallback: skip
       duplicate_action: skip
       log: /config/import.log
 
     audible:
-      fetch_art: yes
-      match_chapters: yes
-      # Negative-ish weight makes Audible matches win over MusicBrainz.
-      source_weight: 0.0
+      # Match files to Audible chapters when file count == chapter count.
+      match_chapters: true
+      # The correct knob to stop Audible being penalised as a non-default
+      # source (this replaces the invalid `source_weight` used before).
+      data_source_mismatch_penalty: 0.0
+      fetch_art: true
+      include_narrator_in_artists: true
+      write_description_file: true
+      write_reader_file: true
       region: us
 
-    # Carry the sidecar files beets-audible generates into the library so
-    # audiobookshelf picks up metadata without re-matching every book.
+    scrub:
+      auto: yes
+
+    # Carry any source-side sidecars into the library. The audible plugin writes
+    # desc.txt / reader.txt / cover itself; this covers a hand-dropped
+    # metadata.yml or cover that should override the Audible lookup.
     filetote:
-      extensions: .opf .jpg .png .cue
-      filenames: cover.jpg desc.txt reader.txt metadata.opf
+      extensions: .opf .jpg .png .cue .yml
+      filenames: cover.jpg metadata.opf metadata.yml
       pairing:
         enabled: no
 
     paths:
+      # Series books nest under the series with the entry number.
+      "albumtype:audiobook series_name::.+ series_position::.+": $albumartist/%ifdef{series_name}/%ifdef{series_position} - $album%aunique{}/$track - $title
+      "albumtype:audiobook series_name::.+": $albumartist/%ifdef{series_name}/$album%aunique{}/$track - $title
+      # Stand-alone books.
+      "albumtype:audiobook": $albumartist/$album%aunique{}/$track - $title
       default: $albumartist/$album%aunique{}/$track - $title
       singleton: $albumartist/$album%aunique{}/$title
-      comp: $albumartist/$album%aunique{}/$track - $title


### PR DESCRIPTION
## Symptom

The beets cronjob logs `Skipping.` for every book:

```
/input/03 Clay's Ark (1 items)
Skipping.

/input/Clive Barker - The Hellbound Heart A Novel (1 items)
Skipping.
```

## Cause

The [beets-audible](https://github.com/Neurrone/beets-audible) config was wrong in three ways that suppress matches. In `--quiet` mode an unconfirmed match falls straight to `quiet_fallback: skip`, so a suppressed match = a skipped book.

1. **Missing `musicbrainz: enabled: no`** — the plugin *requires* this. MusicBrainz has no audiobooks; its candidate noise is what dropped Audible matches below the quiet auto-apply threshold. **Main fix.**
2. **`source_weight: 0.0` was a no-op** — not a real audible option. The plugin's actual knob is `audible.data_source_mismatch_penalty: 0.0`.
3. **Missing `scrub` + generic paths** — added `scrub` (clears messy source tags before the plugin writes clean ones) and the recommended series-aware `albumtype:audiobook` path templates, plus the extra audible output options (narrator in artists, desc/reader files).

## What to expect after merge

Fixing the MusicBrainz noise should push most books over the strong-match line and they'll import + organize into `Author/Book`. This stays **headless** (`--quiet`), so genuinely ambiguous books are still left in `/input` by design rather than misfiled — beets-audible's whole matching flow (press `E` for title/author, `R` for region) is interactive.

**If a meaningful pile still skips after this**, the next step is an occasional interactive import pass (or loosening match thresholds, at the cost of misfile risk). Say the word and I'll wire up an interactive path — e.g. a long-running beets pod you `kubectl exec` into for the residual.

## Validation

Embedded `config.yaml` round-trips as valid YAML; `musicbrainz.enabled`, `data_source_mismatch_penalty`, `scrub`, and the series path keys verified present. `kustomize build` (parent) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)