### PR TITLE
beets: make audiobook matching work (threshold + tag-cleanup + interactive shell)

### DIFF
--- a/kubernetes/apps/default/beets/app/configmap.yaml
+++ b/kubernetes/apps/default/beets/app/configmap.yaml
@@ -28,6 +28,17 @@ data:
     musicbrainz:
       enabled: no
 
+    # beets' default strong_rec_thresh (0.04) is tuned for music matched via
+    # MusicBrainz IDs. Audiobook matching is text-only (title/author vs the
+    # Audible catalogue), so genuine matches land higher — verified 0.07 for a
+    # clean title, ~0.12 once a stray tag prefix is stripped. Below this
+    # distance a match is treated as "strong" and auto-applied in --quiet mode
+    # instead of skipped. 0.15 clears real matches while still rejecting
+    # 0-candidate / wrong-book cases (those skip regardless). Lower it if a
+    # wrong book ever gets auto-filed.
+    match:
+      strong_rec_thresh: 0.15
+
     import:
       # /input entries are hardlinks to files transmission is still seeding.
       # /input (192.168.10.101) and /audiobooks (192.168.10.3) are different

--- a/kubernetes/apps/default/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/default/beets/app/helmrelease.yaml
@@ -37,10 +37,11 @@ spec:
               repository: ghcr.io/gtronset/beets-audiobooks
               tag: 2.2.0
             # The image is linuxserver-based, so its entrypoint is the s6
-            # supervisor (/init) and never exits. Invoke beet directly —
-            # PUID/PGID setup is replaced by the pod securityContext below.
-            command: ["beet"]
-            args: ["import", "--quiet", "/input"]
+            # supervisor (/init) and never exits. Override it with the driver
+            # script, which normalizes tags then runs the headless import.
+            # PUID/PGID setup is replaced by the securityContext below.
+            command: ["/bin/sh"]
+            args: ["/scripts/run.sh"]
             env:
               TZ: America/Chicago
               BEETSDIR: /beets
@@ -51,13 +52,42 @@ spec:
               limits:
                 memory: 2Gi
             restartPolicy: Never
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1024
-            runAsGroup: 100
-            fsGroup: 100
-            fsGroupChangePolicy: OnRootMismatch
+
+      # On-demand shell for the exceptions the cronjob can't auto-match
+      # (0-candidate / ambiguous books). Kept scaled to 0; bring it up only
+      # to run an INTERACTIVE `beet import`, which needs the E/R prompts:
+      #   kubectl -n default patch cronjob beets -p '{"spec":{"suspend":true}}'
+      #   kubectl -n default scale deploy/beets-shell --replicas=1
+      #   kubectl -n default exec -it deploy/beets-shell -- beet import /input
+      #   kubectl -n default scale deploy/beets-shell --replicas=0
+      #   kubectl -n default patch cronjob beets -p '{"spec":{"suspend":false}}'
+      # Suspending the cron first keeps two pods off the one RWO SQLite library.
+      shell:
+        type: deployment
+        replicas: 0
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gtronset/beets-audiobooks
+              tag: 2.2.0
+            command: ["sleep", "infinity"]
+            env:
+              TZ: America/Chicago
+              BEETSDIR: /beets
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 2Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1024
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
 
     service:
       beets:
@@ -76,6 +106,13 @@ spec:
         name: beets-config
         globalMounts:
           - path: /beets
+      scripts:
+        enabled: true
+        type: configMap
+        name: beets-scripts
+        defaultMode: 0555
+        globalMounts:
+          - path: /scripts
       # Output of the m4b-convert cronjob, which is fed in turn by the
       # transmission host's script-torrent-done hook. Everything here is
       # already a single M4B.

--- a/kubernetes/apps/default/beets/app/kustomization.yaml
+++ b/kubernetes/apps/default/beets/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./helmrelease.yaml
   - ./config-pvc.yaml
   - ./configmap.yaml
+  - ./scriptsconfigmap.yaml

--- a/kubernetes/apps/default/beets/app/scriptsconfigmap.yaml
+++ b/kubernetes/apps/default/beets/app/scriptsconfigmap.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: beets-scripts
+  namespace: default
+data:
+  run.sh: |
+    #!/bin/sh
+    # Cronjob entrypoint: normalize messy source tags so the Audible search
+    # terms are clean, then run the headless import. Tag cleanup is best-effort
+    # and never blocks the import.
+    set -eu
+    echo "[normalize] cleaning tags under /input"
+    python3 /scripts/normalize-tags.py /input || echo "[normalize] non-fatal error, continuing to import"
+    echo "[import] beet import --quiet /input"
+    exec beet import --quiet /input
+
+  normalize-tags.py: |
+    #!/usr/bin/env python3
+    """Normalize messy audiobook tags so beets/Audible search terms are clean.
+
+    Runs before `beet import`. Edits are hardlink-safe: each file is copied to a
+    fresh inode which then atomically replaces the ingest name, so a passthrough
+    book still hardlinked to a seeding torrent is never modified in place — the
+    torrent keeps its own pristine link.
+    """
+    import os
+    import re
+    import shutil
+    import sys
+    import tempfile
+    from mutagen.mp4 import MP4
+
+    # Leading track-number prefix on an album/title: "03 X", "03 - X", "03. X".
+    LEADING_NUM = re.compile(r"^\s*\d{1,3}\s*[-.]?\s+")
+    # Trailing contributor-role annotation on an artist: "... - introduction".
+    ROLE_SUFFIX = re.compile(
+        r"\s*[-–]\s*(introduction|foreword|afterword|preface|translator|"
+        r"translated by|narrator|read by|contributor)\b.*$",
+        re.IGNORECASE,
+    )
+
+    ALBUM = "\xa9alb"
+    ARTIST = "\xa9ART"
+    TITLE = "\xa9nam"
+
+
+    def clean_title(v):
+        return LEADING_NUM.sub("", v).strip()
+
+
+    def clean_artist(v):
+        v = ROLE_SUFFIX.sub("", v)
+        return v.strip().rstrip(",").strip()
+
+
+    RULES = {ALBUM: clean_title, TITLE: clean_title, ARTIST: clean_artist}
+
+
+    def process(path):
+        m = MP4(path)
+        changed = {}
+        for key, fn in RULES.items():
+            vals = m.tags.get(key) if m.tags else None
+            if vals:
+                new = fn(vals[0])
+                if new and new != vals[0]:
+                    changed[key] = (vals[0], new)
+        if not changed:
+            return False
+        d = os.path.dirname(path)
+        fd, tmp = tempfile.mkstemp(dir=d, suffix=".m4b")
+        os.close(fd)
+        try:
+            shutil.copyfile(path, tmp)  # fresh inode; breaks the ingest hardlink
+            mt = MP4(tmp)
+            for key, (_old, new) in changed.items():
+                mt.tags[key] = [new]
+            mt.save()
+            os.replace(tmp, path)  # atomic swap of our link only
+        except BaseException:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise
+        for key, (old, new) in changed.items():
+            print(f"    {key}: {old!r} -> {new!r}")
+        return True
+
+
+    def audio_files(root):
+        for book in sorted(os.listdir(root)):
+            if book.startswith("."):
+                continue
+            p = os.path.join(root, book)
+            if os.path.isdir(p):
+                for r, _dirs, fs in os.walk(p):
+                    for f in fs:
+                        if f.lower().endswith((".m4b", ".m4a")):
+                            yield os.path.join(r, f)
+            elif p.lower().endswith((".m4b", ".m4a")):
+                yield p
+
+
+    def main(root):
+        for f in audio_files(root):
+            try:
+                if process(f):
+                    print(f"  normalized: {os.path.relpath(f, root)}")
+            except Exception as e:  # noqa: BLE001 - best-effort, never block import
+                print(f"  skip {f!r}: {e}", file=sys.stderr)
+
+
+    if __name__ == "__main__":
+        main(sys.argv[1] if len(sys.argv) > 1 else "/input")


### PR DESCRIPTION
Diagnosed against the live cronjob + a debug pod, then fixed in three parts. Together they turn "everything skips" into "well-tagged and common-junk books auto-import; only true oddballs need a human."

## 1. Raise `strong_rec_thresh` (root cause of the skips)

The `audible` plugin loads and Audible is reachable — books were matching *correctly* (e.g. `The Hellbound Heart` at Distance **0.07**) but beets' default `match.strong_rec_thresh` is **0.04** (tuned for MusicBrainz-ID music). Audiobook matching is text-only, so genuine matches land higher and in `--quiet` mode a non-strong match goes to `quiet_fallback: skip`.

```yaml
match:
  strong_rec_thresh: 0.15
```

## 2. Auto-normalize tags before import

Some books returned **0 Audible candidates** because of junk source tags — no threshold fixes zero candidates:
- `03 Clay's Ark` — stray track-number prefix on the album
- `John Steinbeck, David Wyatt - introduction` — role suffix on the artist

New `beets-scripts` ConfigMap: `run.sh` strips those (leading `NN ` album/title prefixes, `- introduction`-style artist suffixes) then imports. **Hardlink-safe** — copies each file to a fresh inode and atomically replaces the ingest name, so a passthrough book still hardlinked to a seeding torrent is never touched. Verified: `03 Clay's Ark` → `Clay's Ark` → auto-imports as `Octavia E. Butler/Patternist/3 - Clay's Ark`.

## 3. On-demand interactive shell for the exceptions

A `shell` deployment controller (`replicas: 0`, `sleep infinity`) sharing all the beets mounts. For 0-candidate / ambiguous books that need beets-audible's interactive `E`/`R` prompts:

```
kubectl -n default patch cronjob beets -p '{"spec":{"suspend":true}}'
kubectl -n default scale deploy/beets-shell --replicas=1
kubectl -n default exec -it deploy/beets-shell -- beet import /input
kubectl -n default scale deploy/beets-shell --replicas=0
kubectl -n default patch cronjob beets -p '{"spec":{"suspend":false}}'
```

Suspend the cron first so two pods don't contend on the one RWO SQLite library. (securityContext moved to `defaultPodOptions` so both controllers share it.)

## Result on your three books

| Book | Before | After |
|---|---|---|
| The Hellbound Heart | skip | auto-imports (threshold) |
| 03 Clay's Ark | skip (0 candidates) | auto-imports (tag-cleanup + threshold) |
| East of Eden "introduction" | skip | still an exception → interactive shell |

## Validation

`kustomize build` passes; both controllers render (cronjob → `/scripts/run.sh`, shell deployment `replicas: 0`) with all five mounts and the shared securityContext; `run.sh` is `sh -n` clean and `normalize-tags.py` parses. Normalize + match verified end-to-end in a pod against the exact config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)