### PR TITLE
feat: scoped write RBAC for the beets import agent (+ statefulset shell)

### DIFF
--- a/.taskfiles/beets/Taskfile.yaml
+++ b/.taskfiles/beets/Taskfile.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: '3'
+
+# Interactive audiobook imports for the exceptions the beets cronjob skips
+# (0-candidate or ambiguous books that need beets-audible's E/R prompts).
+#
+# Each task suspends the cron, brings up the beets-shell deployment, drops you
+# into an interactive `beet import`, then — via defer, even on failure or
+# Ctrl-C — scales the shell back to 0 and resumes the cron. Suspending first
+# keeps two pods off the single RWO SQLite library.
+
+vars:
+  NS: default
+
+tasks:
+
+  import:
+    desc: Interactively import skipped audiobooks [BOOK=/input/... optional]
+    interactive: true
+    vars:
+      BOOK: '{{.BOOK | default "/input"}}'
+    cmds:
+      - kubectl --namespace {{.NS}} patch cronjob beets --type merge --patch '{"spec":{"suspend":true}}'
+      - defer: kubectl --namespace {{.NS}} patch cronjob beets --type merge --patch '{"spec":{"suspend":false}}'
+      # Let any in-flight cron import finish before the shell claims the volume.
+      - kubectl --namespace {{.NS}} wait --for=delete pod --selector app.kubernetes.io/name=beets --timeout=90s || true
+      - kubectl --namespace {{.NS}} scale statefulset beets-shell --replicas=1
+      - defer: kubectl --namespace {{.NS}} scale statefulset beets-shell --replicas=0
+      - kubectl --namespace {{.NS}} rollout status statefulset beets-shell --timeout=120s
+      - kubectl --namespace {{.NS}} exec -it beets-shell-0 -- beet import "{{.BOOK}}"
+    preconditions:
+      - test -f {{.KUBECONFIG}}
+      - which kubectl
+      - kubectl --namespace {{.NS}} get statefulset beets-shell
+
+  shell:
+    desc: Open a shell in the beets pod (inspect tags, run beet by hand)
+    interactive: true
+    cmds:
+      - kubectl --namespace {{.NS}} patch cronjob beets --type merge --patch '{"spec":{"suspend":true}}'
+      - defer: kubectl --namespace {{.NS}} patch cronjob beets --type merge --patch '{"spec":{"suspend":false}}'
+      - kubectl --namespace {{.NS}} wait --for=delete pod --selector app.kubernetes.io/name=beets --timeout=90s || true
+      - kubectl --namespace {{.NS}} scale statefulset beets-shell --replicas=1
+      - defer: kubectl --namespace {{.NS}} scale statefulset beets-shell --replicas=0
+      - kubectl --namespace {{.NS}} rollout status statefulset beets-shell --timeout=120s
+      - kubectl --namespace {{.NS}} exec -it beets-shell-0 -- bash
+    preconditions:
+      - test -f {{.KUBECONFIG}}
+      - which kubectl
+      - kubectl --namespace {{.NS}} get statefulset beets-shell

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -19,6 +19,7 @@ env:
   TALOSCONFIG: '{{.TALOSCONFIG}}'
 
 includes:
+  beets: .taskfiles/beets
   bootstrap: .taskfiles/bootstrap
   talos: .taskfiles/talos
 

--- a/kubernetes/apps/default/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/default/beets/app/helmrelease.yaml
@@ -54,16 +54,15 @@ spec:
             restartPolicy: Never
 
       # On-demand shell for the exceptions the cronjob can't auto-match
-      # (0-candidate / ambiguous books). Kept scaled to 0; bring it up only
-      # to run an INTERACTIVE `beet import`, which needs the E/R prompts:
-      #   kubectl -n default patch cronjob beets -p '{"spec":{"suspend":true}}'
-      #   kubectl -n default scale deploy/beets-shell --replicas=1
-      #   kubectl -n default exec -it deploy/beets-shell -- beet import /input
-      #   kubectl -n default scale deploy/beets-shell --replicas=0
-      #   kubectl -n default patch cronjob beets -p '{"spec":{"suspend":false}}'
-      # Suspending the cron first keeps two pods off the one RWO SQLite library.
+      # (0-candidate / ambiguous books) that need beets-audible's E/R prompts.
+      # Kept scaled to 0; drive it with `task beets:import` (which suspends the
+      # cron, scales this up, execs an interactive import, then reverses it).
+      #
+      # A StatefulSet, not a Deployment, so the pod has a STABLE name
+      # (beets-shell-0). That lets the ai-agent-readonly RBAC pin pods/exec to
+      # exactly that pod instead of granting exec across the namespace.
       shell:
-        type: deployment
+        type: statefulset
         replicas: 0
         containers:
           app:

--- a/kubernetes/apps/kube-system/ai-agent-readonly/beets-write.yaml
+++ b/kubernetes/apps/kube-system/ai-agent-readonly/beets-write.yaml
@@ -1,0 +1,50 @@
+---
+# Narrow write grant layered on top of the cluster-wide read-only role, so the
+# ai-agent-readonly account can drive the beets exception-import workflow
+# (see `task beets:import`) and nothing else. Scoped by resourceNames to the
+# single beets cronjob and the beets-shell StatefulSet in the default namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ai-agent-beets-write
+  namespace: default
+rules:
+  # Suspend / resume the import cronjob.
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    resourceNames: ["beets"]
+    verbs: ["get", "patch", "update"]
+  # Scale the interactive shell up/down (kubectl scale hits the scale
+  # subresource; patch/update on the object covers a direct replicas patch).
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    resourceNames: ["beets-shell"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets/scale"]
+    resourceNames: ["beets-shell"]
+    verbs: ["get", "patch", "update"]
+  # Run the interactive import. The StatefulSet gives the pod a stable name, so
+  # exec is pinned to exactly beets-shell-0 — not the whole namespace.
+  - apiGroups: [""]
+    resources: ["pods"]
+    resourceNames: ["beets-shell-0"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    resourceNames: ["beets-shell-0"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ai-agent-beets-write
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ai-agent-beets-write
+subjects:
+  - kind: ServiceAccount
+    name: ai-agent-readonly
+    namespace: kube-system

--- a/kubernetes/apps/kube-system/ai-agent-readonly/kustomization.yaml
+++ b/kubernetes/apps/kube-system/ai-agent-readonly/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./serviceaccount.yaml
+  - ./beets-write.yaml


### PR DESCRIPTION
Lets the `ai-agent-readonly` account drive `task beets:import` from a chat agent (phone) and **nothing else**, layered on the existing cluster-wide read-only role.

## Why the StatefulSet change is bundled

#480 squash-merged with the shell as a **Deployment** and without the task wrappers. A Deployment's pod has a random name (`beets-shell-<hash>`), which can't be pinned in RBAC — so `pods/exec` would have to be granted across the whole `default` namespace. Switching the shell to a **StatefulSet** (still `replicas: 0`) gives it a stable name, `beets-shell-0`, so exec can be scoped to exactly that one pod. That's the tighter grant you picked.

## The grant (namespaced Role in `default`, by resourceName)

| Resource | Names | Verbs |
|---|---|---|
| `batch/cronjobs` | `beets` | get, patch, update |
| `apps/statefulsets` | `beets-shell` | get, patch, update |
| `apps/statefulsets/scale` | `beets-shell` | get, patch, update |
| `pods` | `beets-shell-0` | get |
| `pods/exec` | `beets-shell-0` | create |

No cluster-wide write. The agent can suspend/resume the importer, scale the shell up/down, and exec into `beets-shell-0` — but cannot exec into any other pod in `default` (home-assistant, immich, paperless, …), nor touch any other cronjob/statefulset.

## Also in here

- Shell controller Deployment → StatefulSet (`beets-shell-0`).
- The beets taskfile (`task beets:import` / `task beets:shell`) — never landed on main from #480 — retargeted to the statefulset and the stable pod.

## Validation

`kustomize build` (default + kube-system) passes; the Role renders scoped exactly as above; the RBAC objects pass `kubectl apply --dry-run=server`; `task --list` shows both beets tasks.

## Note

RBAC scopes what the token *can* do, not what a prompt-injected agent *should*. Even pinned, the agent can exec into `beets-shell-0`, which has write access to the audiobook NFS share and the beets library — so treat that token like a credential to that data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)