### PR TITLE
fix(ai-agent): preserve beets RBAC namespace

### DIFF
--- a/kubernetes/apps/kube-system/ai-agent-readonly/ks.yaml
+++ b/kubernetes/apps/kube-system/ai-agent-readonly/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-ai-agent-readonly
+  namespace: kube-system
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/ai-agent-readonly
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -13,6 +13,6 @@ resources:
   # Spegel removed: cluster-wide containerd registry mirrors now handle local caching.
   # - ./spegel/ks.yaml
   - ./local-path-provisioner/ks.yaml
-  - ./ai-agent-readonly
+  - ./ai-agent-readonly/ks.yaml
   - ./uptime-kuma-monitor
 


### PR DESCRIPTION
## Summary
- apply ai-agent-readonly via its own Flux Kustomization instead of directly under the kube-system parent kustomization
- prevents the parent namespace transformer from rewriting the beets write Role/RoleBinding into kube-system
- preserves ai-agent-beets-write in default where cronjob/beets and statefulset/beets-shell live
 
## Verification
- kustomize build kubernetes/apps/kube-system shows only the Flux Kustomization for ai-agent-readonly
- kustomize build kubernetes/apps/kube-system/ai-agent-readonly preserves ai-agent-beets-write Role/RoleBinding namespace: default