### PR TITLE
feat(default): add MouseSearch

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - ./mealie/ks.yaml
   - ./miniflux/ks.yaml
   - ./mosquitto/ks.yaml
+  - ./mousesearch/ks.yaml
   - ./n8n/ks.yaml
   - ./opencloud/ks.yaml
   - ./paperless-ngx/ks.yaml

--- a/kubernetes/apps/default/mousesearch/app/externalsecret.yaml
+++ b/kubernetes/apps/default/mousesearch/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mousesearch
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mousesearch-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        QUART_SECRET_KEY: "{{ .QUART_SECRET_KEY }}"
+        MAM_ID: "{{ .MAM_ID }}"
+        TORRENT_CLIENT_USERNAME: "{{ .TORRENT_CLIENT_USERNAME }}"
+        TORRENT_CLIENT_PASSWORD: "{{ .TORRENT_CLIENT_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: mousesearch
+  refreshInterval: 5m

--- a/kubernetes/apps/default/mousesearch/app/externalsecret.yaml
+++ b/kubernetes/apps/default/mousesearch/app/externalsecret.yaml
@@ -17,8 +17,6 @@ spec:
       data:
         QUART_SECRET_KEY: "{{ .QUART_SECRET_KEY }}"
         MAM_ID: "{{ .MAM_ID }}"
-        TORRENT_CLIENT_USERNAME: "{{ .TORRENT_CLIENT_USERNAME }}"
-        TORRENT_CLIENT_PASSWORD: "{{ .TORRENT_CLIENT_PASSWORD }}"
   dataFrom:
     - extract:
         key: mousesearch

--- a/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
@@ -1,0 +1,109 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mousesearch
+  namespace: default
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: mousesearch
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      mousesearch:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: sevenlayercookie/mousesearch
+              tag: latest
+            env:
+              TZ: America/Chicago
+              PUID: "1000"
+              PGID: "100"
+              DATA_PATH: /data
+
+              TORRENT_CLIENT_TYPE: transmission
+              TORRENT_CLIENT_URL: http://192.168.10.101:9091
+              TORRENT_CLIENT_CATEGORY: audiobooks
+
+              # MouseSearch talks to MAM directly by default. Enable and set
+              # MAM_PROXY_URL in the secret/config UI later if MAM requires the
+              # same VPN/proxy egress as Transmission.
+              MAM_PROXY_ENABLED: "false"
+              MAM_PROXY_ONLY: "true"
+              MAM_PROXY_FALLBACK_DIRECT: "true"
+
+              # Keep account-changing automation opt-in. Friends can search and
+              # add torrents, but MouseSearch will not auto-buy VIP/upload credit.
+              ENABLE_DYNAMIC_IP_UPDATE: "false"
+              AUTO_BUY_VIP: "false"
+              AUTO_BUY_UPLOAD_ON_RATIO: "false"
+              AUTO_BUY_UPLOAD_ON_BUFFER: "false"
+              AUTO_BUY_UPLOAD_ON_BONUS: "false"
+              AUTO_BUY_PERSONAL_FL_ON_DOWNLOAD: "false"
+              BLOCK_DOWNLOAD_ON_LOW_BUFFER: "true"
+
+              AUTO_ORGANIZE_ON_ADD: "false"
+              AUTO_ORGANIZE_ON_SCHEDULE: "false"
+              LOCAL_TORRENT_DOWNLOAD_PATH: /downloads/torrents
+              REMOTE_TORRENT_DOWNLOAD_PATH: /downloads/torrents
+              ORGANIZED_PATH: /downloads/organized
+              DEFAULT_RELATIVE_PATH_TEMPLATE: "{Author}/{Title}"
+
+              MAX_SEARCH_RESULTS: "50"
+              RESULTS_DISPLAY_FIELDS: narrator,series,file_size,file_type,seeders
+              RESULTS_SORT_MODE: quality_desc
+              HARDCOVER_ENRICHMENT_ENABLED: "false"
+              APP_LOG_LEVEL: INFO
+              ACCESS_LOGFILE: /dev/null
+            envFrom:
+              - secretRef:
+                  name: mousesearch-secret
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+    service:
+      app:
+        ports:
+          http:
+            port: &port 5000
+
+    # No direct route: exposed only via the Authentik proxy outpost.
+    # See ./httproute.yaml.
+
+    persistence:
+      data:
+        enabled: true
+        type: nfs
+        server: 192.168.10.3
+        path: /volume1/cluster/mousesearch/data
+        globalMounts:
+          - path: /data
+      downloads:
+        enabled: true
+        type: nfs
+        server: 192.168.10.101
+        path: /downloads
+        globalMounts:
+          - path: /downloads

--- a/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
               DATA_PATH: /data
 
               TORRENT_CLIENT_TYPE: transmission
-              TORRENT_CLIENT_URL: http://192.168.10.101:9091
+              TORRENT_CLIENT_URL: http://192.168.10.10:9091
               TORRENT_CLIENT_CATEGORY: audiobooks
 
               # MouseSearch talks to MAM directly by default. Enable and set

--- a/kubernetes/apps/default/mousesearch/app/httproute.yaml
+++ b/kubernetes/apps/default/mousesearch/app/httproute.yaml
@@ -1,0 +1,23 @@
+---
+# mousesearch fronted by the Authentik embedded proxy outpost.
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mousesearch-auth
+  namespace: default
+spec:
+  hostnames:
+    - mousesearch.kalde.in
+  parentRefs:
+    - name: external
+      namespace: kube-system
+      sectionName: https
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          namespace: security
+          port: 80

--- a/kubernetes/apps/default/mousesearch/app/kustomization.yaml
+++ b/kubernetes/apps/default/mousesearch/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/mousesearch/app/ocirepository.yaml
+++ b/kubernetes/apps/default/mousesearch/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mousesearch
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/mousesearch/ks.yaml
+++ b/kubernetes/apps/default/mousesearch/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-mousesearch
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/default/mousesearch/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/access-control.yaml
@@ -116,6 +116,9 @@ data:
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, audiobookshelf]], group: !KeyOf group-homelab }
         attrs: { order: 0, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, mousesearch]], group: !KeyOf group-homelab }
+        attrs: { order: 0, enabled: true }
 
       # ── friends -> apps shared with people outside the household ────
       # Audiobookshelf auto-registers OIDC users (authOpenIDAutoRegister),
@@ -125,6 +128,9 @@ data:
         attrs: { order: 1, enabled: true }
       - model: authentik_policies.policybinding
         identifiers: { target: !Find [authentik_core.application, [slug, stirling-pdf]], group: !KeyOf group-friends }
+        attrs: { order: 1, enabled: true }
+      - model: authentik_policies.policybinding
+        identifiers: { target: !Find [authentik_core.application, [slug, mousesearch]], group: !KeyOf group-friends }
         attrs: { order: 1, enabled: true }
 
       # ── Paperless -> you + shared users (multi-user, OIDC) ──────────

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -267,6 +267,33 @@ data:
           meta_description: Comics
           policy_engine_mode: any
 
+      # ── mousesearch ──────────────────────────────────────────────────
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-mousesearch
+        state: present
+        identifiers:
+          name: mousesearch
+        attrs:
+          name: mousesearch
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: https://mousesearch.kalde.in
+          internal_host: http://mousesearch.default.svc.cluster.local:5000
+          internal_host_ssl_validation: false
+      - model: authentik_core.application
+        id: app-mousesearch
+        state: present
+        identifiers:
+          slug: mousesearch
+        attrs:
+          name: MouseSearch
+          slug: mousesearch
+          provider: !KeyOf provider-mousesearch
+          meta_launch_url: https://mousesearch.kalde.in
+          meta_description: MyAnonamouse audiobook search
+          policy_engine_mode: any
+
       # ── wiki / OtterWiki (multi-user; PROXY_HEADER auth) ────────────────
       # OtterWiki has no OIDC; it reads identity from reverse-proxy headers.
       # The outpost injects x-otterwiki-name/email/permissions via the scope
@@ -497,6 +524,7 @@ data:
             - !KeyOf provider-zigbee2mqtt
             - !KeyOf provider-teslamate
             - !KeyOf provider-kapowarr
+            - !KeyOf provider-mousesearch
             - !KeyOf provider-wiki
             - !KeyOf provider-sonarr
             - !KeyOf provider-radarr


### PR DESCRIPTION
## Summary

- Add MouseSearch as a `default` namespace app at <https://mousesearch.kalde.in>
- Configure it for MAM search and unauthenticated local Transmission downloads
- Mount persistent app data plus the downloads NFS export
- Expose through the Authentik embedded proxy outpost
- Grant access to both `homelab` and `friends` groups

## Secrets required

Create/update a 1Password item named `mousesearch` with fields:

- `QUART_SECRET_KEY` — random session-signing secret; generate with `openssl rand -hex 32`
- `MAM_ID` — dedicated MyAnonamouse `mam_id` cookie for MouseSearch

## Notes

- Uses `sevenlayercookie/mousesearch:latest` because upstream’s compose example publishes `latest`; we can pin later if upstream tags releases.
- Account-changing automation is disabled by default:
  - VIP auto-buy off
  - upload-credit auto-buy off
  - dynamic IP update off
- Low-buffer download blocking remains enabled.

## Verification

- `kustomize build kubernetes/apps/default`
- `kustomize build kubernetes/apps/default/mousesearch/app`
- `kustomize build kubernetes/apps/security/authentik/app`
- `kustomize build kubernetes/apps/default/mousesearch/app | kubeconform -strict -ignore-missing-schemas -summary`
- `kustomize build kubernetes/apps/security/authentik/app | kubeconform -strict -ignore-missing-schemas -summary`