### PR TITLE
fix(mousesearch): use downloads user and longhorn data

### DIFF
--- a/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
               tag: latest
             env:
               TZ: America/Chicago
-              PUID: "1000"
+              PUID: "1024"
               PGID: "100"
               DATA_PATH: /data
 


### PR DESCRIPTION
## Summary

- Run MouseSearch as UID `1024` / GID `100` for access to the downloads NFS mount.
- Move MouseSearch `/data` from NFS to a Longhorn-backed RWO volume.

## Context

The pod was failing with:

```text
chown: changing ownership of '/data': Operation not permitted
ERROR: UID 1000 cannot read /app or write /data — check volume permissions
```

`/data` is MouseSearch config/cache/state, so it does not need to be on NFS. Longhorn is a better fit for this single-writer app data and avoids root-squash ownership problems. The `/downloads` mount remains NFS.

## Verification

- `kustomize build kubernetes/apps/default/mousesearch/app`
- `kustomize build kubernetes/apps/default/mousesearch/app | kubeconform -strict -ignore-missing-schemas -summary`