### PR TITLE
fix(mousesearch): use longhorn for app data

### DIFF
--- a/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
@@ -93,11 +93,13 @@ spec:
     # See ./httproute.yaml.
 
     persistence:
+      # MouseSearch config/cache/state. Keep this on block storage: it is
+      # single-writer app data and avoids root-squash ownership issues on NFS.
       data:
         enabled: true
-        type: nfs
-        server: 192.168.10.3
-        path: /volume1/cluster/mousesearch/data
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        storageClass: longhorn
         globalMounts:
           - path: /data
       downloads:


### PR DESCRIPTION
## Summary

- Move MouseSearch `/data` from NFS to a Longhorn-backed RWO volume.

## Context

`/data` is MouseSearch config/cache/state, so it does not need to be on NFS. Longhorn is a better fit for this single-writer app data and avoids root-squash ownership problems.

The `/downloads` mount remains NFS.

## Verification

- `kustomize build kubernetes/apps/default/mousesearch/app`
- `kustomize build kubernetes/apps/default/mousesearch/app | kubeconform -strict -ignore-missing-schemas -summary`
