### PR TITLE
fix(beets): threshold 0.25 + strip (Unabridged) so subtitle titles import

### DIFF
--- a/kubernetes/apps/default/beets/app/configmap.yaml
+++ b/kubernetes/apps/default/beets/app/configmap.yaml
@@ -30,14 +30,16 @@ data:
 
     # beets' default strong_rec_thresh (0.04) is tuned for music matched via
     # MusicBrainz IDs. Audiobook matching is text-only (title/author vs the
-    # Audible catalogue), so genuine matches land higher — verified 0.07 for a
-    # clean title, ~0.12 once a stray tag prefix is stripped. Below this
-    # distance a match is treated as "strong" and auto-applied in --quiet mode
-    # instead of skipped. 0.15 clears real matches while still rejecting
-    # 0-candidate / wrong-book cases (those skip regardless). Lower it if a
-    # wrong book ever gets auto-filed.
+    # Audible catalogue), so genuine matches land higher — 0.07 for a clean
+    # title, ~0.12 once a stray tag prefix is stripped, and up to ~0.21 when the
+    # file title carries a subtitle Audible omits (e.g. "Getting to Yes:
+    # Negotiating Agreement Without Giving In" vs Audible's "Getting to Yes").
+    # Below this distance a match is auto-applied in --quiet mode instead of
+    # skipped. 0.25 clears subtitle/edition differences; beets still skips
+    # ambiguous cases (two close candidates) and 0-candidate cases regardless.
+    # Lower it if a wrong book ever gets auto-filed.
     match:
-      strong_rec_thresh: 0.15
+      strong_rec_thresh: 0.25
 
     import:
       # /input entries are hardlinks to files transmission is still seeding.

--- a/kubernetes/apps/default/beets/app/scriptsconfigmap.yaml
+++ b/kubernetes/apps/default/beets/app/scriptsconfigmap.yaml
@@ -34,6 +34,11 @@ data:
 
     # Leading track-number prefix on an album/title: "03 X", "03 - X", "03. X".
     LEADING_NUM = re.compile(r"^\s*\d{1,3}\s*[-.]?\s+")
+    # Trailing "(Unabridged)" / "(Abridged)" edition marker — Audible titles
+    # never carry it, so it only inflates match distance. (Subtitles after ":"
+    # are left alone: they're often part of the real title, e.g. "Star Wars:
+    # Thrawn", and the match threshold absorbs the ones Audible omits.)
+    EDITION = re.compile(r"\s*\((?:un)?abridged\)\s*$", re.IGNORECASE)
     # Trailing contributor-role annotation on an artist: "... - introduction".
     ROLE_SUFFIX = re.compile(
         r"\s*[-–]\s*(introduction|foreword|afterword|preface|translator|"
@@ -47,7 +52,7 @@ data:
 
 
     def clean_title(v):
-        return LEADING_NUM.sub("", v).strip()
+        return EDITION.sub("", LEADING_NUM.sub("", v)).strip()
 
 
     def clean_artist(v):


### PR DESCRIPTION
End-to-end test of the pipeline surfaced one last matching gap on a real book.

## What happened

The transmission hook staged **Getting to Yes** → m4b-convert passed it to `converted/` → beets **skipped** it. But the match was *correct*:

```
Candidate: Roger Fisher, William Ury - Getting to Yes (B004X1T8G4)   Distance: 0.21
Candidate: Derek Borthwick - The Art of Negotiation...               Distance: 0.86
```

Same ASIN as the file's cue (`B004X1T8G4`), second candidate miles away — no ambiguity. It skipped purely because 0.21 > the 0.15 threshold. The distance came from the file title carrying a subtitle + edition marker Audible drops: `Getting to Yes: Negotiating Agreement Without Giving In (Unabridged)` vs Audible's plain `Getting to Yes`.

## Fix

- **`strong_rec_thresh` 0.15 → 0.25** — absorbs subtitle/edition differences. beets still skips genuinely ambiguous (two close candidates) and 0-candidate cases, so it's not a blanket "accept anything."
- **normalize strips a trailing `(Unabridged)`/`(Abridged)`** — Audible never carries it. Subtitles after `:` are deliberately left alone (often part of the real title, e.g. `Star Wars: Thrawn`); the threshold handles those instead.

Measured effect on this book: as-is 0.21 (skipped at 0.15) → imports at 0.25; and cleaning the title fully drops it to **0.00**.

## Validation

`kustomize build` passes, embedded python parses, and a pod run with the updated normalize + config confirms: `(Unabridged)` stripped, book imports as `Roger Fisher, William Ury/Getting to Yes`.

## After merge

`Getting to Yes` is still sitting in `converted/`, so the next beets run (or a manual trigger) will import it automatically once this is live — no re-staging needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)