### PR TITLE
fix(beets): treat .nfo as clutter so imports self-clean

### DIFF
--- a/kubernetes/apps/default/beets/app/configmap.yaml
+++ b/kubernetes/apps/default/beets/app/configmap.yaml
@@ -22,6 +22,13 @@ data:
     asciify_paths: yes
     art_filename: cover
 
+    # Files beets treats as disposable when pruning the source dir after a move.
+    # Torrent .nfo files aren't audio and aren't in filetote's carry list, so
+    # without this they get left behind in a near-empty folder under converted/.
+    # Listing them here lets beets delete the folder outright on import.
+    # (Keeps the beets defaults Thumbs.DB / .DS_Store.)
+    clutter: ["Thumbs.DB", ".DS_Store", "*.nfo"]
+
     # beets-audible REQUIRES MusicBrainz disabled: it has no audiobooks, and
     # its noise is what dropped Audible matches below the quiet auto-apply bar,
     # so everything fell through to quiet_fallback: skip.


### PR DESCRIPTION
`Managing Humans` imported fine but left a near-empty folder in `converted/` holding just its torrent `.nfo` — beets moves the audio + filetote's sidecars to the library but doesn't recognize `.nfo`, so the source folder isn't fully emptied and doesn't get pruned.

Add `*.nfo` to beets' `clutter` list. On a move-import, beets deletes clutter files and prunes the (now truly empty) source dir — so no leftover folder. Keeps the beets defaults (`Thumbs.DB`, `.DS_Store`).

Future books self-clean; the one existing `Managing Humans` leftover in `converted/` needs a one-time manual delete (it's already imported).

Validated: `kustomize build` passes, embedded config parses with the new `clutter` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)