### PR TITLE
feat(beets): auto-trigger Audiobookshelf scan after import

### DIFF
--- a/kubernetes/apps/default/beets/app/configmap.yaml
+++ b/kubernetes/apps/default/beets/app/configmap.yaml
@@ -17,7 +17,7 @@ data:
     # (this runs headless). 'scrub' clears the messy source tags so the audible
     # plugin can write clean ones; 'filetote' carries source-side sidecars
     # (metadata.yml, cover) into the library.
-    plugins: audible fromfilename scrub filetote
+    plugins: audible fromfilename scrub filetote hook
 
     asciify_paths: yes
     art_filename: cover
@@ -69,6 +69,16 @@ data:
 
     scrub:
       auto: yes
+
+    # Audiobookshelf's inotify watcher can't see NFS writes made by another
+    # client (beets writes the library from a different node), so it never
+    # auto-detects new books. Poke its scan API instead: on every imported
+    # album, run the helper that triggers an ABS library scan. Needs ABS_TOKEN
+    # (from the beets-secret ExternalSecret) and ABS_URL in the pod env.
+    hook:
+      hooks:
+        - event: album_imported
+          command: python3 /scripts/abs-scan.py
 
     # Carry any source-side sidecars into the library. The audible plugin writes
     # desc.txt / reader.txt / cover itself; this covers a hand-dropped

--- a/kubernetes/apps/default/beets/app/externalsecret.yaml
+++ b/kubernetes/apps/default/beets/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: beets
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: beets-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Audiobookshelf API token for the post-import scan hook. Create a
+        # "beets" item in 1Password with an ABS_TOKEN field (an ABS API token
+        # from Settings -> Users -> your admin user -> API token).
+        ABS_TOKEN: "{{ .ABS_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: beets
+  refreshInterval: 5m

--- a/kubernetes/apps/default/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/default/beets/app/helmrelease.yaml
@@ -45,6 +45,11 @@ spec:
             env:
               TZ: America/Chicago
               BEETSDIR: /beets
+              ABS_URL: http://audiobookshelf:13378
+            envFrom:
+              # ABS_TOKEN for the post-import Audiobookshelf scan hook.
+              - secretRef:
+                  name: beets-secret
             resources:
               requests:
                 cpu: 100m
@@ -73,6 +78,11 @@ spec:
             env:
               TZ: America/Chicago
               BEETSDIR: /beets
+              ABS_URL: http://audiobookshelf:13378
+            envFrom:
+              # ABS_TOKEN so manual imports via this shell also trigger a scan.
+              - secretRef:
+                  name: beets-secret
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/default/beets/app/kustomization.yaml
+++ b/kubernetes/apps/default/beets/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./config-pvc.yaml
   - ./configmap.yaml
   - ./scriptsconfigmap.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/default/beets/app/scriptsconfigmap.yaml
+++ b/kubernetes/apps/default/beets/app/scriptsconfigmap.yaml
@@ -16,6 +16,58 @@ data:
     echo "[import] beet import --quiet /input"
     exec beet import --quiet /input
 
+  abs-scan.py: |
+    #!/usr/bin/env python3
+    """Trigger an Audiobookshelf library scan after beets imports a book.
+
+    Fired by the beets `hook` plugin on album_imported. ABS's inotify watcher
+    can't see NFS writes from another client, so we poke its API instead. Uses
+    only the stdlib (present in the image) — no curl/jq dependency. Best-effort:
+    a failure here logs but must not fail the import, so it always exits 0.
+    """
+    import json
+    import os
+    import sys
+    import urllib.request
+
+    ABS_URL = os.environ.get("ABS_URL", "http://audiobookshelf:13378").rstrip("/")
+    TOKEN = os.environ.get("ABS_TOKEN")
+
+
+    def api(method, path):
+        req = urllib.request.Request(
+            ABS_URL + path,
+            data=b"" if method == "POST" else None,
+            headers={"Authorization": f"Bearer {TOKEN}"},
+            method=method,
+        )
+        return urllib.request.urlopen(req, timeout=15)
+
+
+    def main():
+        if not TOKEN:
+            print("[abs-scan] ABS_TOKEN not set; skipping scan", file=sys.stderr)
+            return
+        try:
+            libs = json.load(api("GET", "/api/libraries")).get("libraries", [])
+        except Exception as e:  # noqa: BLE001
+            print(f"[abs-scan] could not list libraries: {e}", file=sys.stderr)
+            return
+        # Scan only book libraries (skip any podcast library).
+        for lib in libs:
+            if lib.get("mediaType") != "book":
+                continue
+            try:
+                api("POST", f"/api/libraries/{lib['id']}/scan")
+                print(f"[abs-scan] triggered scan for '{lib.get('name')}' ({lib['id']})")
+            except Exception as e:  # noqa: BLE001
+                print(f"[abs-scan] scan failed for {lib['id']}: {e}", file=sys.stderr)
+
+
+    if __name__ == "__main__":
+        main()
+        sys.exit(0)
+
   normalize-tags.py: |
     #!/usr/bin/env python3
     """Normalize messy audiobook tags so beets/Audible search terms are clean.


### PR DESCRIPTION
Option B from the discussion: beets tells Audiobookshelf to scan after it imports a book, so new books show up in ABS without a manual rescan.

## Why not the ABS watcher

ABS's built-in inotify/chokidar watcher only sees *local* filesystem changes. beets writes the library over NFS from a different node, and inotify never receives events for another NFS client's writes — so the watcher is blind to new books. Poking the API is the reliable path for this topology.

## How

- **beets `hook` plugin** fires on `album_imported` → runs `abs-scan.py`.
- **`abs-scan.py`** (pure stdlib — no curl/jq): `GET /api/libraries`, then `POST /api/libraries/{id}/scan` for each `mediaType: book` library. Best-effort — logs and exits 0, so a scan failure never fails an import. Multiple books in one run each fire a scan; ABS scans are incremental, so that's cheap and the last one catches everything.
- **Env**: `ABS_URL=http://audiobookshelf:13378` + `ABS_TOKEN` via a new `beets-secret` ExternalSecret (1Password, mirroring the mousesearch pattern). Wired to both the cron and the shell controller, so manual `task beets:import` runs trigger a scan too.

## Validation

`kustomize build` passes; `abs-scan.py` and the hook config parse; helm render shows the secret + `ABS_URL` on both controllers. Live test in-cluster: the script reaches `audiobookshelf:13378` and returns a clean `401` on a bogus token (confirms URL/endpoint/error-handling), exit 0.

## ⚠️ One manual step before this works

Create the ABS token and store it:
1. In Audiobookshelf: **Settings → Users → (your admin user) → API token** — copy it.
2. In 1Password: create an item named **`beets`** with a field **`ABS_TOKEN`** set to that token.

Until the `beets` 1Password item exists, the ExternalSecret won't populate and the hook logs `ABS_TOKEN not set` (imports still work, just no auto-scan). Once it's there, Flux syncs the secret and scans start firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)