### PR TITLE
feat(m4b-convert): wrap bare audio-file torrents into a directory

### DIFF
--- a/kubernetes/apps/default/m4b-convert/app/configmap.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/configmap.yaml
@@ -162,13 +162,29 @@ data:
       case "$name" in .*) continue ;; esac
       found=$((found + 1))
 
+      # Some torrents are a single bare audio file. Wrap it in a same-named
+      # directory so the directory logic below handles it uniformly (m4b-tool's
+      # merge wants a directory, not a file). A bare non-audio file just fails.
       if [ -f "$src" ]; then
         case "$name" in
-          *.m4b|*.M4B|*.m4a|*.M4A) passthrough "$src" "${name%.*}" ;;
-          *.mp3|*.MP3)             do_merge "$src" "${name%.*}" transcode ;;
-          *)                       fail "$src" "$name" ;;
+          *.m4b|*.M4B|*.m4a|*.M4A|*.mp3|*.MP3)
+            base=${name%.*}
+            dir="$IN/$base"
+            mkdir -p "$dir"
+            mv "$src" "$dir/"
+            src="$dir"
+            name="$base"
+            log "wrapped bare file into dir: $name"
+            ;;
+          *)
+            fail "$src" "$name"
+            continue
+            ;;
         esac
-      elif has_ext "$src" mp3; then
+      fi
+
+      # Directory handling. Bare files were wrapped above, so $src is a dir.
+      if has_ext "$src" mp3; then
         do_merge "$src" "$name" transcode
       elif has_ext "$src" m4b || has_ext "$src" m4a; then
         # One m4b in the folder: already final, just move it. Multiple parts:


### PR DESCRIPTION
Case 1 of the two special-case handlers.

Some torrents are a single bare `.m4b`/`.mp3` file. Bare `.m4b` already worked (passthrough wraps it in a folder), but bare `.mp3` was passed to `m4b-tool merge` as a **file**, and merge expects a **directory** — so those failed.

## Change

At the top of the dispatch loop, a bare `.m4b`/`.m4a`/`.mp3` is moved into a same-named directory (`Foo.mp3` → `Foo/Foo.mp3`), then falls through to the existing directory logic. Everything downstream now only ever sees directories. Bare non-audio files still go to `failed/`. All moves are renames within `/ingest`, so hardlinks to the seeding torrent are preserved.

## Verified (mock m4b-tool)

| Input | Result |
|---|---|
| bare `.m4b` | wrapped → passthrough (no transcode) |
| bare `.mp3` | wrapped → transcode-merge on the dir ✅ (was broken) |
| bare non-audio | → `failed/` |
| mp3 folder / single-m4b folder / two-part m4b | unchanged, no regression |

Case 2 (nested subfolders, tag-heuristic flatten + `review/` quarantine) is the follow-up, on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)