### PR TITLE
fix(home-assistant): drop the broken Goodnight button from the Home view

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/dashboards/home.yaml
+++ b/kubernetes/apps/default/home-assistant/app/dashboards/home.yaml
@@ -18,13 +18,6 @@ views:
           - entity: device_tracker.claysphone
             name: ClaysPhone
 
-      - type: button
-        name: Goodnight
-        icon: mdi:weather-night
-        tap_action:
-          action: perform-action
-          perform_action: script.goodnight
-
       - type: heading
         heading: Lights
         heading_style: title


### PR DESCRIPTION
The Goodnight button on the Home view of the Elmdon dashboard called `script.goodnight`, and tapping it did nothing.

Rather than fix the action, the button is removed — it wasn't wanted on the Home view.

Scope:
- Removes only the `button` card from the `Home` view.
- The dedicated **Goodnight** view (`path: goodnight`) is unchanged, including its own Goodnight button and the "Turned off by Goodnight" / "Left alone by Goodnight" entity lists. If that view's button is also broken, it's still broken — separate follow-up.

Note: the root cause is unverified. HA scripts live in `/config` on NFS, outside this repo, so I could not confirm whether `script.goodnight` is missing or merely failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)