### PR TITLE
fix(mousesearch): run a patched image so torrent adds work again

### DIFF
--- a/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
@@ -30,9 +30,15 @@ spec:
         strategy: RollingUpdate
         containers:
           app:
+            # TEMPORARY: patched build of v1.1.1 carrying the one-line fix from
+            # sevenlayercookie/MouseSearch#55. Upstream builds the download URL
+            # as /tor/download.php/<dl>, which MAM now rejects with
+            # "Invalid download link: missing tid (torrent id)", so every add to
+            # Transmission fails. Revert to sevenlayercookie/mousesearch:latest
+            # once that PR is merged and released.
             image:
-              repository: sevenlayercookie/mousesearch
-              tag: latest
+              repository: ghcr.io/casmith/mousesearch
+              tag: 4a92d9f9adb729e40b3838de2ad32d78f0bc15a5
             env:
               TZ: America/Chicago
               PUID: "1024"


### PR DESCRIPTION
MouseSearch search works, but every add to Transmission fails:

```
[app] [ERROR] Failed to download torrent file from MAM URL '.../tor/download.php/<dl>':
              Client error '400 Bad Request'
```

MAM stopped accepting the path-only download URL and now wants the torrent id:

```
400 Bad Request
Invalid download link: missing tid (torrent id)
```

Upstream builds the link as `/tor/download.php/<dl>` (`app.py:5186`), so this is broken for everyone, not just us. Filed as sevenlayercookie/MouseSearch#54 with the fix in sevenlayercookie/MouseSearch#55 — one line, appending `?tid=<id>`.

Verified against a live search, same torrent and session:

- `/tor/download.php/<dl>` → 400
- `/tor/download.php/<dl>?tid=<id>` → 200, valid torrent

This points at a patched build of that PR branch so adds work again in the meantime. Image is multi-arch (amd64 + arm64) since the control planes are untainted and the pod can land on either. Pinned by commit sha rather than a moving tag so a rebuild can't silently change what's running.

Revert to `sevenlayercookie/mousesearch:latest` once the upstream PR merges and ships.