### PR TITLE
perf(audiobooks): run the convert/import stages every 5m

### DIFF
--- a/kubernetes/apps/default/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/default/beets/app/helmrelease.yaml
@@ -28,9 +28,13 @@ spec:
           concurrencyPolicy: Forbid
           startingDeadlineSeconds: 60
           # A large import can outrun the interval; Forbid above keeps two
-          # beets processes off the one SQLite library. Offset ten minutes
-          # behind m4b-convert.
-          schedule: "*/15 * * * *"
+          # beets processes off the one SQLite library, and a run that overruns
+          # just skips ticks. Every 5m (an idle run is ~40s) so a freshly
+          # converted book waits at most 5m here instead of 15m. Two minutes
+          # behind m4b-convert's */5; the offset is only to stagger the pods,
+          # since publish into converted/ is an atomic rename and beets can
+          # never see a half-written book whenever it lands.
+          schedule: "2-59/5 * * * *"
         containers:
           app:
             image:

--- a/kubernetes/apps/default/m4b-convert/app/helmrelease.yaml
+++ b/kubernetes/apps/default/m4b-convert/app/helmrelease.yaml
@@ -27,9 +27,13 @@ spec:
         cronjob:
           concurrencyPolicy: Forbid
           startingDeadlineSeconds: 60
-          # Runs ten minutes ahead of the beets import at */15, so a book
-          # converted this cycle is picked up on the next one.
-          schedule: "5,20,35,50 * * * *"
+          # Nothing chains these stages, so each handoff is a queue: a book
+          # waits here for the next tick, then again in converted/ for the next
+          # beets tick. At */15 that was up to 30m of pure waiting on top of the
+          # conversion. Every 5m instead — an idle run is ~3s, so the extra
+          # ticks are free. beets runs at :02 past each, just to keep two
+          # NFS-heavy pods off the same instant.
+          schedule: "*/5 * * * *"
         containers:
           app:
             image:


### PR DESCRIPTION
Books take a long time to show up in Audiobookshelf, and most of it is waiting rather than work.

Nothing chains the three ingest stages, so each handoff is a queue:

| Handoff | Wait |
| --- | --- |
| torrent done → m4b-convert (`5,20,35,50`) | 0–15 min |
| convert done → beets (`*/15`) | 0–15 min |
| **total dead time** | **avg ~15 min, worst 30 min** |

All of that lands on top of the conversion itself. The existing "ten minutes ahead" offset only helps if a conversion finishes inside 10 minutes — a 25-minute transcode publishes at :30 and then waits for :45 anyway.

This drops both to a 5-minute cadence, with beets two minutes behind m4b-convert. Worst-case waiting goes ~30 min → ~10 min.

The extra ticks are free: idle runs measured 3s (m4b-convert) and 38s (beets), and `concurrencyPolicy: Forbid` plus the NFS lock in `convert.sh` already handle a run that overruns its tick — it just skips.

The 2-minute offset is only to keep two NFS-heavy pods off the same instant. Publish into `converted/` is an atomic rename, so beets can't see a half-written book whenever it happens to land.

This is the cheap half of the fix. Collapsing convert into an `initContainer` on the beets CronJob would remove the second handoff entirely rather than just shortening it — worth doing separately, since it changes failure semantics (a convert failure would block that tick's import).