### PR TITLE
fix: stop promtail partial-line buffering and kometa OOM on k8s-pi-6

### DIFF
--- a/kubernetes/apps/default/kometa/app/helmrelease.yaml
+++ b/kubernetes/apps/default/kometa/app/helmrelease.yaml
@@ -21,6 +21,10 @@ spec:
               tag: v2.4.5
             env:
               KOMETA_TIMES: "06:00|18:00"
+              # Countdown redraws with carriage returns and never emits a
+              # newline, which pins promtail on this node at its CPU limit
+              # and OOMs it reassembling one ever-growing log line.
+              KOMETA_NO_COUNTDOWN: "true"
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/apps/default/kometa/app/helmrelease.yaml
+++ b/kubernetes/apps/default/kometa/app/helmrelease.yaml
@@ -28,8 +28,15 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                # Idles at ~128Mi between the twice-daily runs. Without an
+                # explicit request Kubernetes defaults it to the limit, which
+                # reserved the whole peak allocation around the clock.
+                memory: 256Mi
               limits:
-                memory: 750Mi
+                # The episode_info overlay is builder_level: episode, so it
+                # loads all ~14k episodes in one fetch (35MiB of XML, and far
+                # more once plexapi wraps it). 750Mi OOMed every run.
+                memory: 2Gi
     service:
       app:
         ports:

--- a/kubernetes/apps/observability/promtail/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/promtail/app/helmrelease.yaml
@@ -49,7 +49,13 @@ spec:
           kubernetes_sd_configs:
             - role: pod
           pipeline_stages:
-            - cri: {}
+            # Cap partial-line reassembly. Apps that redraw a status line with
+            # carriage returns never emit a newline, so containerd writes one
+            # unterminated CRI record and this stage buffers it forever.
+            - cri:
+                max_partial_lines: 100
+                max_partial_line_size: 65536
+                max_partial_line_size_truncate: true
           relabel_configs:
             # Drop init containers (logs vanish quickly, causes churn)
             - source_labels:


### PR DESCRIPTION
Two related failures on `k8s-pi-6`, both traced to how kometa logs and how much memory it needs.

---

## 1. promtail: unbounded CRI partial-line buffering

`promtail-z4l7m` has been `0/1` for 8 days — OOMKilled 12 times (exit 137) and hard-throttled at its CPU limit.

| Signal | Value |
|---|---|
| CPU | **210m** vs 200m limit (peers: 8–38m) |
| Memory | **217Mi** vs 256Mi limit, OOMKilled ×12 |
| Readiness | probe failed ×59114 over 8d |

### Root cause

Kometa's scheduler countdown (`kometa.py:1588`) redraws with carriage returns and never emits a newline. containerd records that as a single unterminated CRI **partial** record — 2 newlines in a 32KB log file:

```
2026-07-31T10:29:37.6Z stdout P | Current Time: 06:13 | ...^M| Current Time: 06:14 | ...^M...
```

The bare `cri: {}` stage buffers partial records until a newline arrives. It never arrives, so the buffer grows without bound.

### Symptoms this explains

The Loki push timeouts, API-server TLS handshake timeouts, and 8–15 minute `/metrics` scrapes were all downstream of CPU starvation, **not** network faults:

- Loki reachable from pi-6 in **0.3s**
- Peer promtails: **0** push errors in 2h
- Node `k8s-pi-6`: Ready, 35% CPU, 42% mem, no pressure

### Changes

- **`KOMETA_NO_COUNTDOWN=true`** — stops the malformed output at the source. Env var name per the `KOMETA_{ARG_UPPER}` convention at `kometa.py:184`.
- **Cap the `cri` stage** (`max_partial_lines`, `max_partial_line_size`, `max_partial_line_size_truncate`) — defense in depth, so no future carriage-return-emitting container can take down log shipping on its node.

---

## 2. kometa: OOMKilled on every run

Separately, kometa itself has been OOMKilled on **every scheduled run** for at least 5 days — 11 restarts across 5d19h at 2 runs/day, dying ~12 min in. All 10 rotated meta logs are ~4.5MB and stop at the identical point, so TV overlays have not completed since at least Jul 26.

### Root cause

TV Shows enables `default: episode_info`, the only overlay with `builder_level: episode` (`defaults/overlays/episode_info.yml:37`). That forces one unpaginated fetch of every episode in the library.

| | |
|---|---|
| `meta.log` final line | `plex.py:914 Loading All Episodes from Library: TV Shows` @ 06:12:07 |
| Killed | 06:13:29 — 82s later, *inside* that call |
| Episodes | **14,283** (263 shows, 1,002 seasons) |
| Raw episode XML | **35.4 MiB** (measured against Plex) |
| Idle RSS | 128Mi — fine outside this phase |

plexapi holds both the parsed ElementTree and the wrapper objects, amplifying that payload roughly 10–20× on top of what's already resident. `ribbon` and `resolution` are show-level (263 items) and complete fine, so 2Gi only has to cover this one phase.

### Changes

- **`limits.memory: 750Mi` → `2Gi`**
- **Added explicit `requests.memory: 256Mi`** — kometa declared only a limit, so Kubernetes defaulted the request to match and reserved the full peak around the clock for a process that idles at ~128Mi. Sibling apps (miniflux, teslamate) already use a small request with a larger limit. Net effect: pi-6's reservation *drops* from 750Mi to 256Mi even as the ceiling rises.

### Sizing caveat

2Gi is derived from the measured 35.4 MiB payload and a general plexapi amplification factor — it is **not** an observed peak. pi-6 sits at 41% actual memory use, so the twice-daily ~15 min peak has ample headroom, though limits are now overcommitted on paper (~117% of allocatable).

---

## Verification

- `cri` options validated against promtail 3.5.1 via `promtail -check-syntax` → *"Valid config file! No syntax issues found"*
- Both HelmReleases parse and render correctly under `yq`
- Episode counts and XML payload measured directly against the Plex API

## Note

`promtail-z4l7m` is wedged and will not self-recover — the DaemonSet spec change should roll it, but worth confirming it returns to `1/1` after reconcile.

## Unrelated finding

`/config/config.yml` on the kometa NFS share (`0777`) holds a plaintext Plex token, TMDB key, and GitHub PAT. Not touched by this PR; flagging for rotation.
