### PR TITLE
fix(observability): move cri limits to the values key the chart actually reads

### DIFF
--- a/kubernetes/apps/observability/promtail/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/promtail/app/helmrelease.yaml
@@ -42,6 +42,26 @@ spec:
       positions:
         filename: /run/promtail/positions.yaml
 
+      snippets:
+        # Cap partial-line reassembly. Apps that redraw a status line with
+        # carriage returns never emit a newline, so containerd writes one
+        # unterminated CRI record and this stage buffers it forever.
+        #
+        # This must live under config.snippets.pipelineStages: the chart
+        # assembles promtail.yaml from config.file, which reads that key.
+        # A `config.scrape_configs` key does not exist in this chart and is
+        # silently dropped by Helm -- see the dead block below.
+        pipelineStages:
+          - cri:
+              max_partial_lines: 100
+              max_partial_line_size: 65536
+              max_partial_line_size_truncate: true
+
+      # FIXME: dead config. None of the below is read by the chart -- there is
+      # no `config.scrape_configs` value, so Helm silently ignores it and the
+      # rendered config falls back to the chart's default scrape config. The
+      # init-container drop has therefore never taken effect. Migrate to
+      # config.snippets.scrapeConfigs / extraRelabelConfigs, or delete.
       # Scrape configs
       scrape_configs:
         # Scrape pod logs
@@ -49,13 +69,7 @@ spec:
           kubernetes_sd_configs:
             - role: pod
           pipeline_stages:
-            # Cap partial-line reassembly. Apps that redraw a status line with
-            # carriage returns never emit a newline, so containerd writes one
-            # unterminated CRI record and this stage buffers it forever.
-            - cri:
-                max_partial_lines: 100
-                max_partial_line_size: 65536
-                max_partial_line_size_truncate: true
+            - cri: {}
           relabel_configs:
             # Drop init containers (logs vanish quickly, causes churn)
             - source_labels:


### PR DESCRIPTION
Follow-up to #517. **The cri hardening in that PR never took effect.**

## What went wrong

The bounded `cri` stage was set under `config.scrape_configs[0].pipeline_stages`. The promtail chart has **no `config.scrape_configs` value** — it assembles `promtail.yaml` from `config.file`, which reads `config.snippets.pipelineStages`:

```
config.snippets.scrapeConfigs:
  pipeline_stages:
    {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
```

Helm silently drops unknown values, so the rendered secret still contained a bare `cri: {}` and the unbounded partial-line buffering was never capped.

The chart's `config` accepts only: `enabled, logLevel, logFormat, serverPort, clients, positions, enableTracing, snippets, file`.

## Why it slipped through

#517 verified the *promtail config syntax* was valid (`promtail -check-syntax`) but never verified the *chart would consume that key*. Those are different checks, and only the second one mattered here.

## Verification

Rendered the chart with the real values this time:

```
helm template promtail grafana/promtail --version 6.17.1 -f values.yaml
```

```yaml
- job_name: kubernetes-pods
  pipeline_stages:
    - cri:
        max_partial_line_size: 65536
        max_partial_line_size_truncate: true
        max_partial_lines: 100
```

`clients`, `tenant_id` and `positions` still render unchanged.

## Pre-existing bug surfaced (not fixed here)

Because `config.scrape_configs` is ignored, **the entire custom scrape config has never applied** — rendered output has always fallen back to the chart default. Practical consequence: the init-container drop regex (`install-cni-binaries|mount-bpf-fs|clean-cilium-state|…`) has never dropped anything.

Left in place with a `FIXME` rather than migrated to `config.snippets.scrapeConfigs` / `extraRelabelConfigs`, since that is a larger change than this fix and deserves its own review.

## Unaffected

The kometa memory fix in #517 was plain HelmRelease resource values and is working — that pod rolled and is running.
