### PR TITLE
feat(kometa): move yaml config into git, secrets into 1Password

### DIFF
--- a/kubernetes/apps/default/kometa/app/externalsecret.yaml
+++ b/kubernetes/apps/default/kometa/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kometa
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kometa-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Plex is a special case: kometa only substitutes the environment value
+        # when config.yml literally says `token: env` (modules/config.py:2099).
+        KOMETA_PLEX_TOKEN: "{{ .PLEX_TOKEN }}"
+        # Everything else arrives as a kometa "secret" and is substituted into
+        # config.yml wherever <<name>> appears (modules/config.py:490).
+        KOMETA_TMDB_APIKEY: "{{ .TMDB_APIKEY }}"
+        KOMETA_GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: kometa
+  refreshInterval: 5m

--- a/kubernetes/apps/default/kometa/app/helmrelease.yaml
+++ b/kubernetes/apps/default/kometa/app/helmrelease.yaml
@@ -25,6 +25,13 @@ spec:
               # newline, which pins promtail on this node at its CPU limit
               # and OOMs it reassembling one ever-growing log line.
               KOMETA_NO_COUNTDOWN: "true"
+              # config.yml is mounted read-only from the ConfigMap below.
+              # Kometa otherwise writes defaults back into it when an attribute
+              # is missing (modules/config.py:527), which would EROFS.
+              KOMETA_READ_ONLY_CONFIG: "true"
+            envFrom:
+              - secretRef:
+                  name: kometa-secret
             resources:
               requests:
                 cpu: 100m
@@ -58,6 +65,11 @@ spec:
               - identifier: app
                 port: *port
     persistence:
+      # NFS still backs /config: it holds ~5.3GB of real state, chiefly the
+      # "<library> Original Posters" overlay backups. Those are the pre-overlay
+      # artwork keyed by ratingKey; losing them forces kometa to re-fetch from
+      # plex/tmdb (modules/overlays.py:197) and silently replaces any custom
+      # posters. Cache, logs and UUID live here too.
       config:
         enabled: true
         type: nfs
@@ -65,3 +77,147 @@ spec:
         path: /volume1/cluster/kometa
         globalMounts:
           - path: /config
+
+      # Mount the YAML config individually via subPath so /config itself stays
+      # writable for the state above. Mounting the whole directory would make
+      # the cache and overlay backups read-only.
+      config-file:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
+          - path: /config/Movies.yml
+            subPath: Movies.yml
+            readOnly: true
+
+    configMaps:
+      config:
+        data:
+          config.yml: |
+            libraries:
+              Movies:
+                remove_overlays: false
+                collection_files:
+                  - default: basic
+                  - default: imdb
+                  - default: oscars
+                  - file: config/Movies.yml
+                overlay_files:
+                  - default: ribbon
+                  - default: ratings
+                  - default: resolution
+              TV Shows:
+                remove_overlays: false
+                collection_files:
+                  - default: basic
+                  - default: imdb
+                overlay_files:
+                  - default: ribbon
+                  # builder_level: episode -- this is the one that loads all
+                  # ~14k episodes in a single fetch and drives peak memory.
+                  - default: episode_info
+                  - default: resolution
+
+            playlist_files:
+              - default: playlist
+                template_variables:
+                  libraries: Movies, TV Shows
+
+            settings:
+              # All four entries must stay present. If any is missing kometa
+              # rewrites this file (modules/config.py:921) on a path that
+              # KOMETA_READ_ONLY_CONFIG does not guard, which would EROFS.
+              run_order:
+                - operations
+                - metadata
+                - collections
+                - overlays
+              cache: true
+              cache_expiration: 60
+              asset_directory: config/assets
+              asset_folders: true
+              asset_depth: 0
+              create_asset_folders: false
+              prioritize_assets: false
+              dimensional_asset_rename: false
+              download_url_assets: false
+              show_missing_season_assets: false
+              show_missing_episode_assets: false
+              show_asset_not_needed: true
+              sync_mode: append
+              minimum_items: 1
+              default_collection_order:
+              delete_below_minimum: true
+              delete_not_scheduled: false
+              run_again_delay: 2
+              missing_only_released: false
+              only_filter_missing: false
+              show_unmanaged: true
+              show_unconfigured: true
+              show_filtered: false
+              show_options: true
+              show_missing: true
+              show_missing_assets: true
+              save_report: false
+              tvdb_language: eng
+              ignore_ids:
+              ignore_imdb_ids:
+              item_refresh_delay: 0
+              playlist_sync_to_users: all
+              playlist_exclude_users:
+              playlist_report: false
+              verify_ssl: true
+              custom_repo:
+              overlay_artwork_filetype: jpg
+              overlay_artwork_quality: 75
+              show_unfiltered: false
+              auto_sort_hubs:
+
+            plex:
+              url: http://192.168.10.10:32400
+              # Literal "env" -- kometa swaps in KOMETA_PLEX_TOKEN here.
+              token: env
+              timeout: 60
+              db_cache:
+              clean_bundles: false
+              empty_trash: false
+              optimize: false
+              verify_ssl:
+
+            tmdb:
+              apikey: <<tmdb-apikey>>
+              language: en
+              cache_expiration: 60
+              region:
+
+            github:
+              token: <<github-token>>
+
+          Movies.yml: |
+            collections:
+              James Bonds:
+                imdb_list: https://www.imdb.com/list/ls006405458
+                collection_order: custom
+                sync_mode: sync
+              Clay Remedial:
+                imdb_list: https://www.imdb.com/list/ls562894368/
+                collection_order: custom
+                sync_mode: sync
+              Marvel:
+                imdb_list: https://www.imdb.com/list/ls000024621/
+                collection_order: custom
+                sync_mode: sync
+              Studio Ghibli:
+                imdb_list: https://www.imdb.com/list/ls076439519/
+                collection_order: custom
+                sync_mode: sync
+              Star Trek Universe:
+                imdb_list: https://www.imdb.com/list/ls062347197/
+                collection_order: custom
+                sync_mode: sync
+              Star Wars Universe:
+                imdb_list: https://www.imdb.com/list/ls024732224/
+                collection_order: custom
+                sync_mode: sync

--- a/kubernetes/apps/default/kometa/app/kustomization.yaml
+++ b/kubernetes/apps/default/kometa/app/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
`config.yml` and `Movies.yml` lived only on the NFS share — unversioned, unreviewable, and holding a plaintext Plex token, TMDB key and GitHub PAT. Both now come from a ConfigMap; the three credentials come from 1Password via ExternalSecret.

> [!IMPORTANT]
> **Do not merge until the `kometa` item exists in 1Password.** `envFrom` references `kometa-secret`; if the ExternalSecret can't resolve, the pod won't start.

## Required 1Password item

Item `kometa`, following the miniflux convention, with fields:

| Field | Value |
|---|---|
| `PLEX_TOKEN` | rotated Plex token |
| `TMDB_APIKEY` | rotated TMDB key |
| `GITHUB_TOKEN` | rotated GitHub PAT |

Field names are trivially adjustable in `externalsecret.yaml` if you use a different convention.

## Kometa has two substitution mechanisms — they are not interchangeable

**Plex uses a sentinel.** `modules/config.py:2096-2099` only substitutes when the value is the literal string `env`:

```python
if params["plex"]["token"].lower() == "env":
    params["plex"]["token"] = self.env_plex_token
```

A `<<plex-token>>` placeholder would **not** work — `KOMETA_PLEX_URL`/`KOMETA_PLEX_TOKEN` are registered in `static_envs` and therefore excluded from the generic secret mechanism.

**Everything else uses `<<placeholder>>`.** Any `KOMETA_<NAME>` env var becomes a kometa secret, substituted by `modules/config.py:490-493`. Kometa logs these as `(redacted)`.

## NFS stays — the remainder is not cache

`/config` holds ~5.3GB, and 98% of it is the `<library> Original Posters` overlay backups: pre-overlay artwork keyed by ratingKey.

| Item | Size | Nature |
|---|---|---|
| `overlays/` Original Posters | **5.3 GB** | Real state — 15,848 files |
| `logs/` | 48 MB | Disposable |
| `config.cache` + `-wal`/`-shm` | ~18.5 MB | Disposable |
| `anidb_cache/` | 7.6 MB | Disposable |
| `UUID` | 36 B | Instance identity |

Losing the poster backups makes kometa re-fetch from plex/tmdb (`modules/overlays.py:197`), which silently replaces any custom artwork. So the YAML is mounted **per-file via subPath**, leaving `/config` writable — the same pattern homepage uses.

## Read-only guard, and one gap

`KOMETA_READ_ONLY_CONFIG=true` stops kometa writing defaults back into the now read-only `config.yml` (`modules/config.py:527`).

⚠️ The `settings.run_order` write-back at `modules/config.py:921` is **not** covered by that flag. It only fires when one of `operations`/`metadata`/`collections`/`overlays` is missing — so **all four must stay present** in the ConfigMap. Commented inline.

## Verification

Rendered against app-template 5.0.1:

```
volumeMounts:
  - {mountPath: /config,            name: config}
  - {mountPath: /config/config.yml, name: config-file, subPath: config.yml, readOnly: true}
  - {mountPath: /config/Movies.yml, name: config-file, subPath: Movies.yml, readOnly: true}
envFrom:
  - secretRef: {name: kometa-secret}
```

`/config` mounts first and the subPath files shadow it. Chart emits `checksum/configMaps`, so the pod rolls automatically on config change (subPath mounts never hot-reload on their own).

**Semantic diff** of the rendered `config.yml` against the live NFS copy:

```
DROPPED: none
ADDED  : none
CHANGED:
  github.token: <secret> -> <<github-token>>  (intended)
  plex.token:   <secret> -> env               (intended)
  tmdb.apikey:  <secret> -> <<tmdb-apikey>>   (intended)
```

## Cutover

1. Rotate the three credentials, put the **new** values in 1Password
2. Merge; confirm kometa starts and the 18:00 run completes
3. Rename the NFS copy to `config.yml.superseded` — it's shadowed and inert, but will confuse whoever reads it next

## Not addressed

`asset_directory: config/assets` points at a directory that doesn't exist. Preserved verbatim rather than silently dropped; worth cleaning up separately.
