### PR TITLE
feat(paperless-ngx)!: upgrade to 3.0.4

### DIFF
--- a/kubernetes/apps/default/kometa/app/externalsecret.yaml
+++ b/kubernetes/apps/default/kometa/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kometa
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kometa-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Plex is a special case: kometa only substitutes the environment value
+        # when config.yml literally says `token: env` (modules/config.py:2099).
+        KOMETA_PLEX_TOKEN: "{{ .PLEX_TOKEN }}"
+        # Everything else arrives as a kometa "secret" and is substituted into
+        # config.yml wherever <<name>> appears (modules/config.py:490).
+        KOMETA_TMDB_APIKEY: "{{ .TMDB_APIKEY }}"
+        KOMETA_GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: kometa
+  refreshInterval: 5m

--- a/kubernetes/apps/default/kometa/app/helmrelease.yaml
+++ b/kubernetes/apps/default/kometa/app/helmrelease.yaml
@@ -25,6 +25,13 @@ spec:
               # newline, which pins promtail on this node at its CPU limit
               # and OOMs it reassembling one ever-growing log line.
               KOMETA_NO_COUNTDOWN: "true"
+              # config.yml is mounted read-only from the ConfigMap below.
+              # Kometa otherwise writes defaults back into it when an attribute
+              # is missing (modules/config.py:527), which would EROFS.
+              KOMETA_READ_ONLY_CONFIG: "true"
+            envFrom:
+              - secretRef:
+                  name: kometa-secret
             resources:
               requests:
                 cpu: 100m
@@ -58,6 +65,11 @@ spec:
               - identifier: app
                 port: *port
     persistence:
+      # NFS still backs /config: it holds ~5.3GB of real state, chiefly the
+      # "<library> Original Posters" overlay backups. Those are the pre-overlay
+      # artwork keyed by ratingKey; losing them forces kometa to re-fetch from
+      # plex/tmdb (modules/overlays.py:197) and silently replaces any custom
+      # posters. Cache, logs and UUID live here too.
       config:
         enabled: true
         type: nfs
@@ -65,3 +77,147 @@ spec:
         path: /volume1/cluster/kometa
         globalMounts:
           - path: /config
+
+      # Mount the YAML config individually via subPath so /config itself stays
+      # writable for the state above. Mounting the whole directory would make
+      # the cache and overlay backups read-only.
+      config-file:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
+          - path: /config/Movies.yml
+            subPath: Movies.yml
+            readOnly: true
+
+    configMaps:
+      config:
+        data:
+          config.yml: |
+            libraries:
+              Movies:
+                remove_overlays: false
+                collection_files:
+                  - default: basic
+                  - default: imdb
+                  - default: oscars
+                  - file: config/Movies.yml
+                overlay_files:
+                  - default: ribbon
+                  - default: ratings
+                  - default: resolution
+              TV Shows:
+                remove_overlays: false
+                collection_files:
+                  - default: basic
+                  - default: imdb
+                overlay_files:
+                  - default: ribbon
+                  # builder_level: episode -- this is the one that loads all
+                  # ~14k episodes in a single fetch and drives peak memory.
+                  - default: episode_info
+                  - default: resolution
+
+            playlist_files:
+              - default: playlist
+                template_variables:
+                  libraries: Movies, TV Shows
+
+            settings:
+              # All four entries must stay present. If any is missing kometa
+              # rewrites this file (modules/config.py:921) on a path that
+              # KOMETA_READ_ONLY_CONFIG does not guard, which would EROFS.
+              run_order:
+                - operations
+                - metadata
+                - collections
+                - overlays
+              cache: true
+              cache_expiration: 60
+              asset_directory: config/assets
+              asset_folders: true
+              asset_depth: 0
+              create_asset_folders: false
+              prioritize_assets: false
+              dimensional_asset_rename: false
+              download_url_assets: false
+              show_missing_season_assets: false
+              show_missing_episode_assets: false
+              show_asset_not_needed: true
+              sync_mode: append
+              minimum_items: 1
+              default_collection_order:
+              delete_below_minimum: true
+              delete_not_scheduled: false
+              run_again_delay: 2
+              missing_only_released: false
+              only_filter_missing: false
+              show_unmanaged: true
+              show_unconfigured: true
+              show_filtered: false
+              show_options: true
+              show_missing: true
+              show_missing_assets: true
+              save_report: false
+              tvdb_language: eng
+              ignore_ids:
+              ignore_imdb_ids:
+              item_refresh_delay: 0
+              playlist_sync_to_users: all
+              playlist_exclude_users:
+              playlist_report: false
+              verify_ssl: true
+              custom_repo:
+              overlay_artwork_filetype: jpg
+              overlay_artwork_quality: 75
+              show_unfiltered: false
+              auto_sort_hubs:
+
+            plex:
+              url: http://192.168.10.10:32400
+              # Literal "env" -- kometa swaps in KOMETA_PLEX_TOKEN here.
+              token: env
+              timeout: 60
+              db_cache:
+              clean_bundles: false
+              empty_trash: false
+              optimize: false
+              verify_ssl:
+
+            tmdb:
+              apikey: <<tmdb-apikey>>
+              language: en
+              cache_expiration: 60
+              region:
+
+            github:
+              token: <<github-token>>
+
+          Movies.yml: |
+            collections:
+              James Bonds:
+                imdb_list: https://www.imdb.com/list/ls006405458
+                collection_order: custom
+                sync_mode: sync
+              Clay Remedial:
+                imdb_list: https://www.imdb.com/list/ls562894368/
+                collection_order: custom
+                sync_mode: sync
+              Marvel:
+                imdb_list: https://www.imdb.com/list/ls000024621/
+                collection_order: custom
+                sync_mode: sync
+              Studio Ghibli:
+                imdb_list: https://www.imdb.com/list/ls076439519/
+                collection_order: custom
+                sync_mode: sync
+              Star Trek Universe:
+                imdb_list: https://www.imdb.com/list/ls062347197/
+                collection_order: custom
+                sync_mode: sync
+              Star Wars Universe:
+                imdb_list: https://www.imdb.com/list/ls024732224/
+                collection_order: custom
+                sync_mode: sync

--- a/kubernetes/apps/default/kometa/app/kustomization.yaml
+++ b/kubernetes/apps/default/kometa/app/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/default/paperless-ngx/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/externalsecret.yaml
@@ -28,7 +28,9 @@ spec:
         PAPERLESS_DBUSER: "{{ .POSTGRES_USER }}"
         PAPERLESS_DBPASS: "{{ .POSTGRES_PASS }}"
         PAPERLESS_DBHOST: postgres17-rw.database.svc.cluster.local
-        PAPERLESS_DBENGINE: postgres
+        # v3 validates this against {sqlite, postgresql, mariadb} and refuses to
+        # start on anything else; "postgres" was only ever tolerated in v2.
+        PAPERLESS_DBENGINE: postgresql
 
         PAPERLESS_ADMIN_USER: "{{ .PAPERLESS_ADMIN_USER }}"
         PAPERLESS_ADMIN_MAIL: "{{ .PAPERLESS_ADMIN_MAIL }}"

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -48,14 +48,21 @@ spec:
           app:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
-              tag: 2.20.15
+              tag: 3.0.4
             env:
               PAPERLESS_REDIS: redis://paperless-ngx-broker.default.svc.cluster.local:6379
               PAPERLESS_TIME_ZONE: America/Chicago
               PAPERLESS_OCR_LANGUAGE: eng
               PAPERLESS_URL: https://documents.kalde.in
-              PAPERLESS_CONSUMER_POLLING: 60
+              # Poll rather than inotify: the consume dir is NFS, where native
+              # filesystem notifications don't fire. v3 renamed this from
+              # PAPERLESS_CONSUMER_POLLING and ignores the old name entirely,
+              # so dropping it here silently stops all consumption.
+              PAPERLESS_CONSUMER_POLLING_INTERVAL: 60
               PAPERLESS_CONSUMER_RECURSIVE: "true"
+              # v3 accepts duplicates by default and only flags them in the UI;
+              # keep the v2 behaviour of rejecting them outright.
+              PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
               # SSO via Authentik (allauth OIDC). The provider JSON (with the
               # client id/secret) is in paperless-ngx-secret. Local login kept
               # as fallback (shared app); link existing accounts by email.


### PR DESCRIPTION
Supersedes #509, which bumped the image tag on its own. The tag bump alone would have broken the deployment.

`2.20.15` is the required starting point for v3, so this is a direct jump with no intermediate hop. Landing `3.0.4` rather than `3.0.0` because 3.0.1 shipped a migration that prevents startup, fixed in 3.0.2.

## Changes

| File | Change |
| --- | --- |
| `app/helmrelease.yaml` | `tag: 2.20.15` → `3.0.4` |
| `app/helmrelease.yaml` | `PAPERLESS_CONSUMER_POLLING` → `PAPERLESS_CONSUMER_POLLING_INTERVAL` (value `60` unchanged) |
| `app/helmrelease.yaml` | added `PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"` |
| `app/externalsecret.yaml` | `PAPERLESS_DBENGINE: postgres` → `postgresql` |

### Why each is required

- **`DBENGINE`** — v3 validates this against `{sqlite, postgresql, mariadb}` and raises `ValueError` at startup on anything else. Our `postgres` was only ever tolerated in v2. Fails loudly rather than silently falling back to SQLite, but it is a hard stop.
- **`CONSUMER_POLLING_INTERVAL`** — the old name is no longer read *at all*, with no warning or fallback. The new default of `0` means native inotify, which does not fire on our NFS consume dir. Without this rename, consumption stops silently while the pod stays green.
- **`CONSUMER_DELETE_DUPLICATES`** — v3 accepts duplicates by default and only flags them in the UI. This restores the v2 behaviour of rejecting them.

Both new variable names were verified against `src/paperless/settings/__init__.py` at the `v3.0.4` tag rather than taken from the docs.

## Verified as needing no action

- `PAPERLESS_SECRET_KEY` is now mandatory — already set in the secret.
- Document encryption was removed and requires `decrypt_documents` *before* upgrading — all 228 documents are `unencrypted`.
- `OCR_MODE=skip` / `OCR_SKIP_ARCHIVE_FILE` were removed — neither is set, and the `ApplicationConfiguration` row is entirely NULL, so nothing needs migrating.
- `CONSUMER_BARCODE_SCANNER` and the `DBSSL*` / `DB_POOLSIZE` / `DB_TIMEOUT` variables were removed or consolidated into `DB_OPTIONS` — none are set.
- Pre/post-consume scripts lost their positional arguments — no scripts are configured.
- The NumPy `x86-64-v2` baseline `SIGILL` is x86_64-only; this runs on arm64, and an arm64 image is published for 3.0.4.

## Rollout notes

The Whoosh index is rebuilt into Tantivy automatically on first start — at 228 documents and a 6.6 MB index, that is seconds. Task history is dropped by the migration, which is expected.

Two things to watch after reconcile, both fixable without a rollback:

- If Authentik login fails at the callback with `invalid_client`, add `"token_auth_method": "client_secret_basic"` to the provider settings in `PAPERLESS_SOCIALACCOUNT_PROVIDERS`.
- allauth changed client-IP detection for login rate limiting. If logins start returning 403, set `PAPERLESS_TRUSTED_PROXIES` / `PAPERLESS_ALLAUTH_TRUSTED_PROXY_COUNT`. Left out here because it needs the real Envoy hop count.

Post-merge checks: pod reaches Ready after migrations, full-text search returns results, a test file dropped in `consume/` is picked up within ~60s, and Authentik SSO login works.
