### PR TITLE
feat(n8n): source the Invoice Ninja API token from 1Password

### DIFF
--- a/kubernetes/apps/default/n8n/app/externalsecret.yaml
+++ b/kubernetes/apps/default/n8n/app/externalsecret.yaml
@@ -20,6 +20,13 @@ spec:
         N8N_RUNNERS_ENABLED: "true"
         N8N_ENCRYPTION_KEY: "{{ .N8N_ENCRYPTION_KEY }}"
 
+        # Source of truth for the Invoice Ninja token used by the
+        # "Add expense from email" workflow. Nothing reads this from the
+        # environment -- expressions can't, since N8N_BLOCK_ENV_ACCESS_IN_NODE
+        # is left at its blocking default. It lives here so the value is
+        # 1Password-managed and available to re-create the n8n credential.
+        INVOICENINJA_API_TOKEN: "{{ .invoiceninja_api_token }}"
+
         DB_POSTGRESDB_DATABASE: n8n
         DB_POSTGRESDB_HOST: postgres17-rw.database.svc.cluster.local
         DB_POSTGRESDB_PORT: "5432"


### PR DESCRIPTION
Adds `INVOICENINJA_API_TOKEN` to the n8n ExternalSecret, sourced from the existing `n8n` 1Password item.

## Why

The token is currently a **plaintext header value in both HTTP nodes** of the `Add expense from email` workflow — readable by anyone with workflow access or a database dump, and it lands in any workflow export.

## Why nothing reads it from the environment

The obvious next step would be `{{ $env.INVOICENINJA_API_TOKEN }}` in the header. That does not work here, and enabling it would be a bad trade.

n8n blocks `$env` in expressions unless explicitly disabled:

```js
// n8n-workflow/dist/cjs/workflow-data-proxy-env-provider.js
const isEnvAccessBlocked = process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE !== 'false';
```

It is not set on this deployment, so access is blocked (it throws `access to env vars denied` rather than silently sending an empty header). Setting it to `false` makes **every** env var readable from **every** expression, including:

| Variable | Why it matters |
| --- | --- |
| `N8N_ENCRYPTION_KEY` | decrypts every stored n8n credential, e.g. the IMAP password |
| `DB_POSTGRESDB_PASSWORD` | the n8n database |
| `INIT_POSTGRES_SUPER_PASS` | Postgres **superuser**, shared across the whole cluster |

Not worth it for one header value.

## What actually consumes the token

An n8n **Header Auth credential**, encrypted at rest and referenced by the HTTP nodes by id — the same pattern the existing `IMAP account` credential uses. That keeps the workflow JSON free of secret material.

This entry exists so the value stays 1Password-managed and the credential can be rebuilt without hunting for it. The credential itself lives in n8n's database and is not GitOps-managed, same as the workflows (see `kubernetes/apps/default/n8n/workflows/README.md`).

## After merge

Reconcile, confirm the key lands in `n8n-secret`, create the credential, repoint both HTTP nodes, and verify with a forwarded receipt.
