### PR TITLE
docs(mousesearch): note that config.json on the PVC overrides env

### DIFF
--- a/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mousesearch/app/helmrelease.yaml
@@ -39,6 +39,18 @@ spec:
             image:
               repository: sevenlayercookie/mousesearch
               tag: v1.1.3
+            # HEADS UP: these env vars are only DEFAULTS. MouseSearch persists
+            # its live config to /data/config.json on the `data` PVC, and that
+            # file WINS over env for every key it contains (load order in
+            # app.py load_config: hardcoded defaults -> env -> config.json).
+            # Any change made in the Settings UI writes the whole config.json,
+            # after which editing an env var here has NO effect on that key.
+            #
+            # Notably TORRENT_CLIENT_CATEGORY and the type->category label rules
+            # (TYPE_SPECIFIC_TORRENT_CATEGORIES, a list-of-dicts that can't be
+            # expressed as env at all) live ONLY in config.json. To change the
+            # audiobooks/ebooks/other routing, use the UI, not this file. See
+            # calypso-deploy transmission/ingest-torrents.sh for the consumer.
             env:
               TZ: America/Chicago
               PUID: "1024"


### PR DESCRIPTION
Adds an inline comment to the mousesearch HelmRelease documenting a config-precedence trap.

MouseSearch loads config as: hardcoded defaults → env → `/data/config.json` (highest priority). The `data` PVC file wins over every env var it contains, and any Settings-UI save rewrites the whole file. So after the routing is configured in the UI, editing `TORRENT_CLIENT_CATEGORY` (or anything else) in this manifest silently has no effect.

The audiobooks/ebooks/other label routing in particular — `TORRENT_CLIENT_CATEGORY` plus `TYPE_SPECIFIC_TORRENT_CATEGORIES` (a list-of-dicts that can't be an env var at all) — lives only in `config.json`. The comment points future edits to the UI and cross-references the hook consumer in calypso-deploy.

Docs only, no behavior change.