### PR TITLE
fix(longhorn): drop defaultReplicaCount, it crashloops the manager

### DIFF
--- a/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
@@ -32,8 +32,15 @@ spec:
         enable: true
         jobList: '[{"name":"default","isGroup":true}]'
     defaultSettings:
-      # Global fallback when a StorageClass does not specify (bumped 2 -> 3).
-      defaultReplicaCount: "3"
+      # NOTE: do not set defaultReplicaCount here. It is DataEngineSpecific, so
+      # Longhorn stores it as {"v1":"3","v2":"3"} while this file would supply a
+      # scalar. shouldApplyCustomizedSettingValue compares those as raw strings,
+      # never matches, and so rewrites the Setting on every manager start —
+      # and UpdateSetting's first write is not wrapped in RetryOnConflict, so a
+      # racing manager fataly exits (daemon.go:111) and crashloops. The built-in
+      # default is already {"v1":"3","v2":"3"} (types/setting.go:809), so this
+      # was redundant anyway. Any DataEngineSpecific setting added here must use
+      # the JSON form, as disable-revision-counter below does.
       defaultLonghornStaticStorageClass: longhorn
       # Only create a default disk (i.e. store replica data) on nodes labeled
       # node.longhorn.io/create-default-disk=true — the amd64 cp nodes. Keeps


### PR DESCRIPTION
`longhorn-manager` has been crashlooping on **k8s-pi-3 (43+ restarts)** and earlier on **k8s-cp-1 (9 restarts)**, both with the same fatal:

```
level=fatal msg="Error starting manager: Operation cannot be fulfilled on
settings.longhorn.io \"default-replica-count\": the object has been modified;
please apply your changes to the latest version and try again"
  func=main.main.DaemonCmd.func3  file="daemon.go:111"
```

## Root cause

`default-replica-count` is **`DataEngineSpecific: true`**, so Longhorn stores it as `{"v1":"3","v2":"3"}` — but this file supplied the scalar `"3"`. `shouldApplyCustomizedSettingValue` compares them as raw strings:

```go
return (setting.Value != value || configMapResourceVersion != defaultSettingCMResourceVersion || definition.Default != value)
```

`{"v1":"3","v2":"3"} != "3"` is permanently true, so **every manager rewrote that Setting on every start, forever.**

`UpdateSetting` then issues two writes and only the second is protected:

```go
obj, err := ...Settings(ns).Update(ctx, setting, ...)   // 1st write — NOT retried
if err != nil { return nil, err }                       // conflict escapes here
err = retry.RetryOnConflict(retry.DefaultRetry, ...)    // 2nd write — retried
```

The conflict propagates to `startManager`, whose only error handling is `logrus.Fatalf`. Whichever manager loses the race exits and crashloops.

Measured across all customized settings — only this one mismatches:

| setting | ConfigMap (parsed) | stored CR | |
|---|---|---|---|
| `default-replica-count` | `3` | `{"v1":"3","v2":"3"}` | **mismatch** |
| `disable-revision-counter` | `{"v1":"true"}` | `{"v1":"true"}` | match |
| `concurrent-automatic-engine-upgrade-per-node-limit` | `3` | `3` | match |
| `priority-class` | `longhorn-critical` | `longhorn-critical` | match |
| `create-default-disk-labeled-nodes` | `true` | `true` | match |
| `default-longhorn-static-storage-class` | `longhorn` | `longhorn` | match |

`disable-revision-counter` was already written in JSON form and never rewrites — that's the correct pattern, kept as the example in the new comment.

## Why removal, not JSON form

**The built-in default is already `{"v1":"3","v2":"3"}`** (`types/setting.go:809`), so this was redundant. The `bumped 2 -> 3` comment predates 1.12, which ships 3. The `longhorn` StorageClass also sets its own count via `persistence.defaultClassReplicaCount: 3`, which is unchanged.

`defaultReplicaCount: '{"v1":"3","v2":"3"}'` would also converge, but redundant config that crashloops the manager is worse than no config.

## Verification

Rendered chart 1.12.0 with these values — emitted `longhorn-default-setting` ConfigMap:

```yaml
create-default-disk-labeled-nodes: true
default-longhorn-static-storage-class: "longhorn"
priority-class: "longhorn-critical"
disable-revision-counter: "{\"v1\":\"true\"}"
concurrent-automatic-engine-upgrade-per-node-limit: "3"
```

`default-replica-count` is gone; the other five are unchanged and each matches its stored CR value, so none rewrite on start.

## Not fixed upstream

The unretried first write in `UpdateSetting` is **identical in v1.10, v1.11, v1.12 and `master`** — upgrading Longhorn would not have helped.

## On merge

Changing the ConfigMap bumps its `resourceVersion`, which invalidates the `longhorn.io/configmap-resource-version` annotation on every Setting. The next manager to start re-applies all of them once. With only pi-3 restarting that's uncontended, so I would **not** pair this with a full DaemonSet roll. pi-3 should recover on its next backoff attempt.
