### PR TITLE
fix(longhorn): give the manager requests so talos stops OOM-killing it

### DIFF
--- a/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
@@ -17,6 +17,26 @@ spec:
         namespace: longhorn-system
       interval: 5m
   values:
+    longhornManager:
+      # Without these the manager has no requests at all, so it lands in the
+      # BestEffort QoS class. Talos runs its own userspace OOM controller which
+      # SIGKILLs whole cgroups under /sys/fs/cgroup/kubepods/besteffort when a
+      # node is short on memory — it took out longhorn-manager on k8s-pi-3
+      # repeatedly. That kill is invisible to Kubernetes: containerd never sees
+      # an OOM event, so the container reports reason=Error rather than
+      # OOMKilled, no eviction event is emitted, and the node still reports
+      # MemoryPressure=False. Requests move it to Burstable so it is no longer
+      # in the first group Talos sweeps.
+      #
+      # Sized from observed steady state across the 11 managers: 242-335Mi,
+      # 15-167m CPU.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+
     # Declarative backup target. The chart owns the `default` BackupTarget CR,
     # so this keeps the setting in git instead of the UI. NFS needs no creds.
     defaultBackupStore:


### PR DESCRIPTION
`longhorn-manager` has been crashlooping on **k8s-pi-3** (and earlier **cp-1**) with both containers exiting `137` *simultaneously* — including the sidecar, which is only `sleep infinity` and cannot fail on its own.

## Root cause

Talos `dmesg` on pi-3:

```
[talos] OOM controller triggered {"component":"controller-runtime","controller":"runtime.OOMController"}
[talos] Sending SIGKILL to cgroup {"cgroup":"/sys/fs/cgroup/kubepods/besteffort/podeb5a15a7-6ea6-4181-a44f-6372f80b3acc"}
[talos] victim processes: [172919, 172886, 172009]
```

Both victim UIDs map to BestEffort pods on that node:

| UID | pod | QoS |
|---|---|---|
| `eb5a15a7…` | `longhorn-manager-rl742` | BestEffort |
| `2741e148…` | `longhorn-csi-plugin-g2c7j` | BestEffort |

**Talos runs its own userspace OOM controller** that SIGKILLs entire cgroups under the `besteffort` slice when a node is short on memory. The chart ships longhorn-manager with `resources: ~`, so it sits in BestEffort and is in the first group swept. Because it's a *cgroup-level* kill, every container in the pod dies at once — which is why the `sleep infinity` sidecar also showed `137`.

## Why this took node-level logs to find

The kill is **invisible from inside Kubernetes**:

- containerd never observes an OOM → container reports `reason=Error`, **not** `OOMKilled`
- no eviction event is emitted
- the node still reports `MemoryPressure=False`, because kubelet's own eviction thresholds are never crossed — Talos acts first, and below kubelet

Every in-cluster OOM/eviction check came back clean. Cilium was healthy, there were no taints, no D-state processes, and no liveness probe that could have killed it.

## Fix

Requests move the pod from BestEffort to **Burstable**. A pod is BestEffort only when *no* container has requests or limits, so the resource-less `pre-pull-share-manager-image` sidecar doesn't prevent the change.

Sized from observed steady state across the 11 managers: **242–335Mi**, **15–167m CPU**.

## Verification

Rendered chart 1.12.0 with these values:

```yaml
name: longhorn-manager
resources:
  limits:   {memory: 512Mi}
  requests: {cpu: 50m, memory: 256Mi}
```

Confirmed against `longhornManager.resources` in the chart's own values (documented as *"Resource requests and limits for Longhorn Manager pods"*) — not a key the chart silently ignores.

## What this does NOT fix

The chart exposes **no `resources` key** for `longhorn-csi-plugin`, `share-manager`, `engine-image`, `longhorn-ui` or `driver-deployer` — I checked the 1.12.0 values, the only `resources` entry is `longhornManager`. Those stay BestEffort and will still be swept. csi-plugin already has 12 restarts on pi-3.

Covering them would need a Kustomize patch on the rendered DaemonSets, which is a bigger change and worth its own review.

**The underlying memory pressure on pi-3 also still wants attention** — it runs 11 BestEffort pods against 6 Burstable (three share-managers, csi-plugin, engine-image, driver-deployer, longhorn-ui) on a 4-core Pi with a 15-min load average of ~4.2, despite hosting no replicas (`allowScheduling=false`).

## Unrelated observation

`longhornManager.updateStrategy.rollingUpdate.maxUnavailable` defaults to **`"100%"`** — all 11 managers restart simultaneously on any chart change. That's what made the `default-replica-count` settings race in #540 fire so reliably. Setting it to `1` would be cheap insurance against that class of startup race.
