### PR TITLE
feat(actions-runner-system): add arch-pinned runner pools for home-ops

### DIFF
--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-ops-runners
+  namespace: actions-runner-system
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-ops-runners-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        github_app_id: "{{ .github_app_id }}"
+        github_app_installation_id: "{{ .github_app_installation_id }}"
+        github_app_private_key: "{{ .github_app_private_key }}"
+  dataFrom:
+    - extract:
+        key: home-ops-github-runner

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
@@ -1,0 +1,89 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: home-ops-runners-amd64
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: home-ops-runners
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: home-ops-runners-secret
+      valuesKey: github_app_id
+      targetPath: githubConfigSecret.github_app_id
+    - kind: Secret
+      name: home-ops-runners-secret
+      valuesKey: github_app_installation_id
+      targetPath: githubConfigSecret.github_app_installation_id
+    - kind: Secret
+      name: home-ops-runners-secret
+      valuesKey: github_app_private_key
+      targetPath: githubConfigSecret.github_app_private_key
+  values:
+    # Repository-level runner pool for home-ops
+    githubConfigUrl: https://github.com/casmith/home-ops
+    runnerScaleSetName: home-ops-runners-amd64
+
+    # Scaling configuration. Scales from zero: these pools exist for the Talos
+    # upgrade workflow, which runs at most one node job at a time.
+    minRunners: 0
+    maxRunners: 2
+
+    # Pinned to the control plane (amd64). Used by jobs that upgrade the arm64
+    # worker nodes, so a runner is never scheduled on the node it is rebooting.
+    listenerTemplate:
+      spec:
+        nodeSelector:
+          kubernetes.io/arch: amd64
+        containers:
+          - name: listener
+
+    # Runner template
+    template:
+      spec:
+        nodeSelector:
+          kubernetes.io/arch: amd64
+        containers:
+          - name: runner
+            image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a
+            command: ["/home/runner/run.sh"]
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 200m
+              limits:
+                memory: 1Gi
+                cpu: 1000m
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+
+        # Storage for runner work directory
+        volumes:
+          - name: work
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  storageClassName: local-path
+                  resources:
+                    requests:
+                      storage: 5Gi
+
+    # Controller settings
+    controllerServiceAccount:
+      namespace: actions-runner-system
+      name: actions-runner-controller

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: home-ops-runners-arm64
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: home-ops-runners
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: home-ops-runners-secret
+      valuesKey: github_app_id
+      targetPath: githubConfigSecret.github_app_id
+    - kind: Secret
+      name: home-ops-runners-secret
+      valuesKey: github_app_installation_id
+      targetPath: githubConfigSecret.github_app_installation_id
+    - kind: Secret
+      name: home-ops-runners-secret
+      valuesKey: github_app_private_key
+      targetPath: githubConfigSecret.github_app_private_key
+  values:
+    # Repository-level runner pool for home-ops
+    githubConfigUrl: https://github.com/casmith/home-ops
+    runnerScaleSetName: home-ops-runners-arm64
+
+    # Scaling configuration. Scales from zero: these pools exist for the Talos
+    # upgrade workflow, which runs at most one node job at a time.
+    minRunners: 0
+    maxRunners: 2
+
+    # Pinned to the Raspberry Pi workers (arm64). Used by jobs that upgrade the
+    # amd64 control plane nodes, so a runner is never scheduled on the node it
+    # is rebooting.
+    listenerTemplate:
+      spec:
+        nodeSelector:
+          kubernetes.io/arch: arm64
+        containers:
+          - name: listener
+
+    # Runner template
+    template:
+      spec:
+        nodeSelector:
+          kubernetes.io/arch: arm64
+        containers:
+          - name: runner
+            image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a
+            command: ["/home/runner/run.sh"]
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 200m
+              limits:
+                memory: 1Gi
+                cpu: 1000m
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+
+        # Storage for runner work directory
+        volumes:
+          - name: work
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  storageClassName: local-path
+                  resources:
+                    requests:
+                      storage: 5Gi
+
+    # Controller settings
+    controllerServiceAccount:
+      namespace: actions-runner-system
+      name: actions-runner-controller

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease-amd64.yaml
+  - ./helmrelease-arm64.yaml

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: home-ops-runners
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-ops-runners
+  namespace: &namespace actions-runner-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: actions-runner-controller
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: home-ops-runners-amd64
+      namespace: *namespace
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: home-ops-runners-arm64
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/actions-runner-system/home-ops-runners/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./binfmt/ks.yaml
   - ./khaoslabs-runners/ks.yaml
   - ./beoftexas-runners/ks.yaml
+  - ./home-ops-runners/ks.yaml


### PR DESCRIPTION
Part A of automating Talos node upgrades. Adds a repository-scoped ARC runner pool for `casmith/home-ops`, which currently has none — every workflow here runs on `ubuntu-latest`, which can't reach `192.168.10.0/24`, and the `khaoslabs` org pool isn't visible to this repo.

## Why two pools

An in-cluster runner dies if its pod happens to sit on the node the job is rebooting. Splitting by arch makes that impossible rather than merely unlikely:

| Scale set (`runs-on`) | Pinned to | Serves |
|---|---|---|
| `home-ops-runners-arm64` | arm64 — the 8 Pis | control plane upgrade jobs |
| `home-ops-runners-amd64` | amd64 — the 3 CPs | worker upgrade jobs |

Control plane nodes run before workers, so neither pool ever has a runner on a node being touched during its phase. Both the listener and the runner pods are pinned — a listener stuck on a rebooting node would stall job assignment just as effectively.

This works because `allowSchedulingOnControlPlanes: true` and the cluster splits cleanly: CPs are amd64, Pis are arm64.

## Layout

Mirrors `beoftexas-runners` (also repository-scoped). One Flux Kustomization, with a single OCIRepository and ExternalSecret shared by both HelmReleases:

```
home-ops-runners/
  ks.yaml
  app/{kustomization,ocirepository,externalsecret,helmrelease-amd64,helmrelease-arm64}.yaml
```

- `minRunners: 0` — scales from zero; the upgrade workflow runs at most one node job at a time, so idle pods earn nothing
- No dind sidecar — these jobs run `talosctl`, they don't build images
- 5Gi ephemeral `local-path` work volume

## Verified

- `ghcr.io/khaoslabs/actions-runner` is multi-arch (amd64 + arm64), so the arm64 pool is viable
- `helm template` at chart 0.14.2 renders cleanly, with `nodeSelector` landing on both `listenerTemplate.spec` and `template.spec`
- `kustomize build` succeeds for the app dir and the parent namespace

## Requires

- GitHub App installed on `casmith/home-ops`
- 1Password item `home-ops-github-runner` with `github_app_id`, `github_app_installation_id`, `github_app_private_key`

## After merge

```bash
kubectl -n actions-runner-system get externalsecret home-ops-runners
kubectl -n actions-runner-system get pods -o wide | grep home-ops-runners
```

Expect `SecretSynced` and two `-listener` pods, one on a Pi and one on a CP. The pools won't show up in GitHub's runner list until the listeners connect.