### PR TITLE
feat(talos): automate node upgrades with a GitHub Actions workflow

### DIFF
--- a/.github/actions/talos-setup/action.yaml
+++ b/.github/actions/talos-setup/action.yaml
@@ -1,0 +1,120 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: Talos Setup
+description: >-
+  Install pinned Talos tooling and generate the talosconfig and kubeconfig that
+  the upgrade jobs need. Tool versions come from .mise.toml so Renovate keeps
+  them current in one place.
+
+inputs:
+  sops-age-key:
+    description: age private key used to decrypt talsecret.sops.yaml
+    required: true
+  exclude-ip:
+    description: >-
+      Control plane IP to keep out of the talosctl endpoint list. Set this to
+      the node a job is about to reboot so its API calls are not routed through
+      the node that is going down.
+    required: false
+    default: ""
+
+outputs:
+  endpoint:
+    description: Control plane IP selected as the talosctl endpoint
+    value: ${{ steps.endpoint.outputs.ip }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install pinned tools
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        case "$(uname -m)" in
+          x86_64) arch=amd64 ;;
+          aarch64 | arm64) arch=arm64 ;;
+          *) echo "::error::unsupported runner architecture $(uname -m)"; exit 1 ;;
+        esac
+
+        # Single source of truth for versions: the repo's .mise.toml
+        pin() {
+          local version
+          version="$(sed -n "s|^\"aqua:$1\" = \"\(.*\)\"|\1|p" .mise.toml)"
+          if [[ -z "$version" ]]; then
+            echo "::error::no pinned version for $1 in .mise.toml"
+            exit 1
+          fi
+          echo "$version"
+        }
+
+        talos_version="$(pin siderolabs/talos)"
+        talhelper_version="$(pin budimanjojo/talhelper)"
+        yq_version="$(pin mikefarah/yq)"
+        kubectl_version="$(pin kubernetes/kubectl)"
+
+        bin="${RUNNER_TEMP}/bin"
+        mkdir -p "$bin"
+
+        echo "talosctl v${talos_version}, talhelper v${talhelper_version}, yq v${yq_version}, kubectl v${kubectl_version} (${arch})"
+
+        curl -fsSL -o "${bin}/talosctl" \
+          "https://github.com/siderolabs/talos/releases/download/v${talos_version}/talosctl-linux-${arch}"
+        curl -fsSL "https://github.com/budimanjojo/talhelper/releases/download/v${talhelper_version}/talhelper_linux_${arch}.tar.gz" \
+          | tar -xz -C "$bin" talhelper
+        curl -fsSL -o "${bin}/yq" \
+          "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_linux_${arch}"
+        curl -fsSL -o "${bin}/kubectl" \
+          "https://dl.k8s.io/release/v${kubectl_version}/bin/linux/${arch}/kubectl"
+
+        chmod +x "${bin}"/*
+        echo "$bin" >> "$GITHUB_PATH"
+
+    - name: Generate Talos configuration
+      shell: bash
+      env:
+        SOPS_AGE_KEY: ${{ inputs.sops-age-key }}
+      run: |
+        set -euo pipefail
+
+        # talhelper decrypts talsecret.sops.yaml and the encrypted patches
+        # itself, so the age key is the only secret needed. clusterconfig/ is
+        # gitignored, which is why every job regenerates it.
+        cd talos
+        talhelper genconfig
+
+        echo "TALOSCONFIG=${GITHUB_WORKSPACE}/talos/clusterconfig/talosconfig" >> "$GITHUB_ENV"
+
+    - name: Select control plane endpoint
+      id: endpoint
+      shell: bash
+      env:
+        EXCLUDE_IP: ${{ inputs.exclude-ip }}
+      run: |
+        set -euo pipefail
+
+        # Route API calls through a control plane node other than the one this
+        # job is about to reboot.
+        ip="$(yq eval -r \
+          ".nodes[] | select(.controlPlane == true) | select(.ipAddress != \"${EXCLUDE_IP}\") | .ipAddress" \
+          talos/talconfig.yaml | head -1)"
+
+        if [[ -z "$ip" ]]; then
+          echo "::error::no control plane node available as an endpoint (excluding ${EXCLUDE_IP})"
+          exit 1
+        fi
+
+        echo "ip=${ip}" >> "$GITHUB_OUTPUT"
+        echo "TALOS_ENDPOINT=${ip}" >> "$GITHUB_ENV"
+        echo "Using control plane endpoint ${ip}"
+
+    - name: Fetch kubeconfig
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        talosctl kubeconfig "${RUNNER_TEMP}/kubeconfig" \
+          --endpoints "${TALOS_ENDPOINT}" \
+          --nodes "${TALOS_ENDPOINT}" \
+          --force
+        echo "KUBECONFIG=${RUNNER_TEMP}/kubeconfig" >> "$GITHUB_ENV"

--- a/.github/actions/talos-upgrade-node/action.yaml
+++ b/.github/actions/talos-upgrade-node/action.yaml
@@ -1,0 +1,194 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: Talos Upgrade Node
+description: >-
+  Upgrade a single Talos node and hold until it is healthy again. Skips nodes
+  already running the target version so a rerun after a partial failure resumes
+  instead of rebooting healthy nodes.
+
+inputs:
+  hostname:
+    description: Talos hostname, as it appears in talconfig.yaml and Kubernetes
+    required: true
+  ip:
+    description: Node IP address
+    required: true
+  target-version:
+    description: Talos version this node should end up on
+    required: true
+  control-plane:
+    description: Whether this node is a control plane member
+    required: false
+    default: "false"
+  dry-run:
+    description: Print the upgrade command instead of running it
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Check current version
+      id: current
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        TARGET: ${{ inputs.target-version }}
+      run: |
+        set -euo pipefail
+
+        # The first "Tag:" belongs to the client, so only read the one that
+        # follows the Server: header.
+        current="$(talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" version --short \
+          | awk '/^Server:/ { server = 1 } server && $1 == "Tag:" { print $2; exit }')" || true
+
+        if [[ -z "$current" ]]; then
+          echo "::error::could not determine the Talos version running on $IP"
+          exit 1
+        fi
+
+        echo "current=${current}" >> "$GITHUB_OUTPUT"
+
+        if [[ "$current" == "$TARGET" ]]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          echo "Already running ${TARGET}"
+        else
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "Running ${current}, upgrading to ${TARGET}"
+        fi
+
+    - name: Record cordon state
+      id: cordon
+      if: steps.current.outputs.skip == 'false'
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+
+        # Remember whether the node was already cordoned so an operator's
+        # deliberate cordon survives this run.
+        was_cordoned="$(kubectl get node "$HOSTNAME_" -o jsonpath='{.spec.unschedulable}')"
+        echo "was-cordoned=${was_cordoned:-false}" >> "$GITHUB_OUTPUT"
+
+    - name: Upgrade
+      if: steps.current.outputs.skip == 'false' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+      run: |
+        set -euo pipefail
+
+        # talhelper resolves the correct factory schematic for this node and the
+        # version from talenv.yaml. talosctl cordons and drains the node itself
+        # (--drain defaults to true) and waits for it to come back (--wait).
+        cd talos
+        talhelper gencommand upgrade \
+          --node "$IP" \
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=25m" \
+          | tee /dev/stderr \
+          | bash
+
+    - name: Show upgrade command (dry run)
+      if: steps.current.outputs.skip == 'false' && inputs.dry-run == 'true'
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+      run: |
+        set -euo pipefail
+        cd talos
+        echo "Would run:"
+        talhelper gencommand upgrade \
+          --node "$IP" \
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=25m"
+
+    - name: Wait for healthy
+      if: steps.current.outputs.skip == 'false' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        HOSTNAME_: ${{ inputs.hostname }}
+        TARGET: ${{ inputs.target-version }}
+        IS_CONTROL_PLANE: ${{ inputs.control-plane }}
+        WAS_CORDONED: ${{ steps.cordon.outputs.was-cordoned }}
+      run: |
+        set -euo pipefail
+
+        deadline=$(( SECONDS + 900 ))
+
+        wait_for() {
+          local description="$1"; shift
+          echo "Waiting for ${description}..."
+          until "$@"; do
+            if (( SECONDS > deadline )); then
+              echo "::error::timed out waiting for ${description} on ${HOSTNAME_}"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "  ${description}: ok"
+        }
+
+        at_target_version() {
+          local current
+          current="$(talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" version --short 2>/dev/null \
+            | awk '/^Server:/ { server = 1 } server && $1 == "Tag:" { print $2; exit }')" || return 1
+          [[ "$current" == "$TARGET" ]]
+        }
+
+        node_ready() {
+          local status
+          status="$(kubectl get node "$HOSTNAME_" \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" || return 1
+          [[ "$status" == "True" ]]
+        }
+
+        etcd_healthy() {
+          local health
+          health="$(talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" service etcd 2>/dev/null \
+            | awk '$1 == "HEALTH" { print $2; exit }')" || return 1
+          [[ "$health" == "OK" ]]
+        }
+
+        wait_for "${HOSTNAME_} to report ${TARGET}" at_target_version
+        wait_for "${HOSTNAME_} to be Ready" node_ready
+
+        if [[ "$IS_CONTROL_PLANE" == "true" ]]; then
+          wait_for "etcd on ${HOSTNAME_} to be healthy" etcd_healthy
+        fi
+
+        # talosctl cordons the node as part of the drain. Undo that unless the
+        # node was already cordoned before this job started.
+        if [[ "$WAS_CORDONED" != "true" ]]; then
+          kubectl uncordon "$HOSTNAME_"
+        else
+          echo "${HOSTNAME_} was cordoned before this run; leaving it cordoned"
+        fi
+
+    - name: Summary
+      if: always()
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+        IP: ${{ inputs.ip }}
+        TARGET: ${{ inputs.target-version }}
+        PREVIOUS: ${{ steps.current.outputs.current }}
+        SKIPPED: ${{ steps.current.outputs.skip }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        JOB_STATUS: ${{ job.status }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$JOB_STATUS" == "failure" ]]; then
+          result="**failed** while on ${PREVIOUS:-an unknown version}"
+        elif [[ "$SKIPPED" == "true" ]]; then
+          result="already on ${TARGET}, skipped"
+        elif [[ "$DRY_RUN" == "true" ]]; then
+          result="dry run, would upgrade ${PREVIOUS:-unknown} to ${TARGET}"
+        else
+          result="upgraded ${PREVIOUS:-unknown} to ${TARGET}"
+        fi
+
+        echo "### ${HOSTNAME_} (${IP})" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "${result}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/talos-upgrade.yaml
+++ b/.github/workflows/talos-upgrade.yaml
@@ -1,0 +1,331 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "Talos Upgrade"
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["talos/talenv.yaml"]
+  workflow_dispatch:
+    inputs:
+      nodes:
+        description: "Comma-separated hostnames to limit the run to (default: every node)"
+        required: false
+        default: ""
+      dry-run:
+        description: "Plan and gate only, without upgrading anything"
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: talos-upgrade
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    name: Plan
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 15
+    outputs:
+      should-run: ${{ steps.plan.outputs.should-run }}
+      talos-version: ${{ steps.plan.outputs.talos-version }}
+      upgrade-k8s: ${{ steps.plan.outputs.upgrade-k8s }}
+      control-plane-matrix: ${{ steps.plan.outputs.control-plane-matrix }}
+      worker-matrix: ${{ steps.plan.outputs.worker-matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+
+      - name: Preflight
+        run: |
+          set -euo pipefail
+
+          # Never start a rollout into an already-degraded cluster: the whole
+          # design assumes the nodes we are not touching can absorb the load.
+          # Read the Ready condition rather than the STATUS column, which also
+          # reports SchedulingDisabled -- a node left cordoned by an earlier
+          # failed run must not block the rerun that fixes it.
+          not_ready=()
+          cordoned=()
+          while read -r hostname ready unschedulable; do
+            [[ "$ready" != "True" ]] && not_ready+=("$hostname")
+            [[ "$unschedulable" == "true" ]] && cordoned+=("$hostname")
+          done < <(kubectl get nodes --no-headers -o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,UNSCHEDULABLE:.spec.unschedulable')
+
+          if (( ${#not_ready[@]} > 0 )); then
+            echo "::error::these nodes are not Ready: ${not_ready[*]}"
+            exit 1
+          fi
+
+          if (( ${#cordoned[@]} > 0 )); then
+            echo "::warning::these nodes are cordoned and will be left cordoned: ${cordoned[*]}"
+          fi
+
+          while read -r hostname ip; do
+            health="$(talosctl --nodes "$ip" --endpoints "$TALOS_ENDPOINT" service etcd \
+              | awk '$1 == "HEALTH" { print $2; exit }')"
+            if [[ "$health" != "OK" ]]; then
+              echo "::error::etcd on ${hostname} reports health ${health:-unknown}"
+              exit 1
+            fi
+            echo "etcd on ${hostname}: OK"
+          done < <(yq eval -r '.nodes[] | select(.controlPlane == true) | .hostname + " " + .ipAddress' talos/talconfig.yaml)
+
+          echo "All nodes Ready, etcd healthy on every control plane member"
+
+      - name: Build plan
+        id: plan
+        env:
+          FILTER: ${{ inputs.nodes }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+
+          target="$(yq eval -r '.talosVersion' talos/talenv.yaml)"
+          k8s_target="$(yq eval -r '.kubernetesVersion' talos/talenv.yaml)"
+          echo "talos-version=${target}" >> "$GITHUB_OUTPUT"
+
+          # Matrices come from talconfig.yaml, so adding a node to the cluster
+          # needs no change here.
+          build_matrix() {
+            local selector="$1" entries=() hostname ip
+            while read -r hostname ip; do
+              if [[ -n "$FILTER" && ",${FILTER}," != *",${hostname},"* ]]; then
+                continue
+              fi
+              entries+=("{\"hostname\":\"${hostname}\",\"ip\":\"${ip}\"}")
+            done < <(yq eval -r ".nodes[] | select(.controlPlane ${selector}) | .hostname + \" \" + .ipAddress" talos/talconfig.yaml)
+            local IFS=,
+            echo "[${entries[*]}]"
+          }
+
+          control_plane_matrix="$(build_matrix '== true')"
+          worker_matrix="$(build_matrix '!= true')"
+          echo "control-plane-matrix=${control_plane_matrix}" >> "$GITHUB_OUTPUT"
+          echo "worker-matrix=${worker_matrix}" >> "$GITHUB_OUTPUT"
+
+          # Decide from live cluster state rather than the git diff. A commit
+          # that only moves kubernetesVersion leaves every node already on the
+          # target Talos version, so nothing reboots.
+          pending=()
+          while read -r hostname os_image; do
+            current="${os_image#*(}"
+            current="${current%)}"
+            if [[ "$current" != "$target" ]]; then
+              pending+=("${hostname} (${current})")
+            fi
+          done < <(kubectl get nodes -o custom-columns='NAME:.metadata.name,IMAGE:.status.nodeInfo.osImage' --no-headers)
+
+          if (( ${#pending[@]} > 0 )); then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Same idea for Kubernetes: compare the running kubelets, not the diff.
+          stale_kubelets="$(kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.kubeletVersion}' \
+            | tr ' ' '\n' | grep -vx "$k8s_target" || true)"
+          if [[ -n "$stale_kubelets" ]]; then
+            echo "upgrade-k8s=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "upgrade-k8s=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "## Talos upgrade plan"
+            echo ""
+            echo "| Setting | Value |"
+            echo "|---|---|"
+            echo "| Target Talos version | \`${target}\` |"
+            echo "| Target Kubernetes version | \`${k8s_target}\` |"
+            echo "| Nodes needing upgrade | ${#pending[@]} |"
+            echo "| Kubernetes upgrade needed | $([[ -n "$stale_kubelets" ]] && echo yes || echo no) |"
+            [[ -n "$FILTER" ]] && echo "| Limited to | \`${FILTER}\` |"
+            [[ "$DRY_RUN" == "true" ]] && echo "| Dry run | yes |"
+            echo ""
+            if (( ${#pending[@]} > 0 )); then
+              echo "Pending: $(printf '%s, ' "${pending[@]}" | sed 's/, $//')"
+            else
+              echo "Every node already runs \`${target}\`. No nodes will be rebooted."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  approve:
+    name: Approve
+    needs: plan
+    if: needs.plan.outputs.should-run == 'true'
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 5
+    environment: talos-upgrade
+    steps:
+      - name: Approved
+        run: |
+          echo "Approved rollout of ${{ needs.plan.outputs.talos-version }}"
+
+  control-plane:
+    name: ${{ matrix.hostname }}
+    needs: [plan, approve]
+    if: needs.approve.result == 'success' && needs.plan.outputs.control-plane-matrix != '[]'
+    # Pinned to the Pi workers so a control plane job is never evicted by the
+    # control plane node it is rebooting.
+    runs-on: home-ops-runners-arm64
+    timeout-minutes: 45
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.control-plane-matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+          exclude-ip: ${{ matrix.ip }}
+
+      - name: Upgrade ${{ matrix.hostname }}
+        uses: ./.github/actions/talos-upgrade-node
+        with:
+          hostname: ${{ matrix.hostname }}
+          ip: ${{ matrix.ip }}
+          target-version: ${{ needs.plan.outputs.talos-version }}
+          control-plane: "true"
+          dry-run: ${{ inputs.dry-run }}
+
+  workers:
+    name: ${{ matrix.hostname }}
+    needs: [plan, approve, control-plane]
+    if: >-
+      !cancelled() && !failure()
+      && needs.approve.result == 'success'
+      && needs.plan.outputs.worker-matrix != '[]'
+    # Pinned to the control plane, which by this point is already upgraded.
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 45
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.worker-matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+
+      - name: Upgrade ${{ matrix.hostname }}
+        uses: ./.github/actions/talos-upgrade-node
+        with:
+          hostname: ${{ matrix.hostname }}
+          ip: ${{ matrix.ip }}
+          target-version: ${{ needs.plan.outputs.talos-version }}
+          control-plane: "false"
+          dry-run: ${{ inputs.dry-run }}
+
+  upgrade-k8s:
+    name: Upgrade Kubernetes
+    needs: [plan, approve, control-plane, workers]
+    if: >-
+      !cancelled() && !failure()
+      && needs.approve.result == 'success'
+      && needs.plan.outputs.upgrade-k8s == 'true'
+      && inputs.dry-run != true
+      && inputs.nodes == ''
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+
+      - name: Upgrade Kubernetes
+        run: |
+          set -euo pipefail
+
+          # Cluster-wide rather than per-node: talosctl rolls the control plane
+          # static pods and kubelets itself.
+          cd talos
+          talhelper gencommand upgrade-k8s \
+            --extra-flags "--endpoints=${TALOS_ENDPOINT}" \
+            | tee /dev/stderr \
+            | bash
+
+      - name: Summary
+        if: always()
+        run: |
+          version="$(yq eval -r '.kubernetesVersion' talos/talenv.yaml)"
+          echo "Kubernetes upgraded to ${version}" >> "$GITHUB_STEP_SUMMARY"
+
+  verify:
+    name: Verify
+    needs: [plan, control-plane, workers, upgrade-k8s]
+    if: ${{ !cancelled() && needs.plan.outputs.should-run == 'true' }}
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+
+      - name: Verify cluster
+        run: |
+          set -euo pipefail
+
+          target="$(yq eval -r '.talosVersion' talos/talenv.yaml)"
+
+          {
+            echo "## Cluster state"
+            echo ""
+            echo "| Node | Talos | Kubelet | Ready |"
+            echo "|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          stale=0
+          # osImage reads "Talos (v1.13.6)" -- it contains a space, so it has to
+          # be the last column or it shifts everything after it.
+          while read -r hostname kubelet ready os_image; do
+            version="${os_image#*(}"
+            version="${version%)}"
+            marker=""
+            if [[ "$version" != "$target" ]]; then
+              marker=" :warning:"
+              stale=$(( stale + 1 ))
+            fi
+            if [[ "$ready" != "True" ]]; then
+              marker="${marker} :warning:"
+              stale=$(( stale + 1 ))
+            fi
+            echo "| ${hostname} | ${version}${marker} | ${kubelet} | ${ready} |" >> "$GITHUB_STEP_SUMMARY"
+          done < <(kubectl get nodes --no-headers -o custom-columns='NAME:.metadata.name,KUBELET:.status.nodeInfo.kubeletVersion,READY:.status.conditions[?(@.type=="Ready")].status,IMAGE:.status.nodeInfo.osImage')
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if (( stale > 0 )); then
+            echo "Some nodes are not on \`${target}\` or are not Ready. Rerun the workflow to resume; nodes already upgraded are skipped." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "Every node runs \`${target}\` and is Ready." >> "$GITHUB_STEP_SUMMARY"

--- a/talos/UPGRADE.md
+++ b/talos/UPGRADE.md
@@ -39,7 +39,47 @@ The cluster uses different Talos factory images (schematics) based on node type:
    mise use -g talhelper@latest
    ```
 
-## Automated Upgrade Process
+## GitHub Actions Workflow (preferred)
+
+`.github/workflows/talos-upgrade.yaml` rolls the whole cluster one node at a
+time. Each node appears as its own job, named after its hostname.
+
+**Trigger.** Merging a change to `talos/talenv.yaml` — typically a Renovate PR
+for `ghcr.io/siderolabs/installer` — starts the workflow. It can also be run by
+hand from the Actions tab, which accepts an optional comma-separated `nodes`
+filter and a `dry-run` toggle.
+
+**Approval.** Nothing reboots until the `Approve` job is released. It is bound
+to the `talos-upgrade` GitHub Environment, which requires a reviewer, so a
+weekend Renovate merge waits for a human. Read the `Plan` job summary first —
+it lists the target version and which nodes are behind it.
+
+**Order.** All three control plane nodes upgrade first, one at a time, then the
+eight Pi workers, one at a time. The first failure stops the rest.
+
+**Reruns are safe.** Each job skips its node if it already reports the target
+version, so re-running after a failure resumes where it stopped rather than
+rebooting healthy nodes.
+
+**Kubernetes.** If `kubernetesVersion` in `talenv.yaml` no longer matches the
+running kubelets, a final job runs `talosctl upgrade-k8s` after every node is
+done. A commit that only moves `kubernetesVersion` therefore upgrades
+Kubernetes without rebooting anything.
+
+The runners live in this cluster, so the workflow pins each phase to the nodes
+it is *not* touching: control plane jobs run on `home-ops-runners-arm64` (the
+Pis) and worker jobs on `home-ops-runners-amd64` (the control plane). Without
+that split, a job would eventually evict itself. See
+`kubernetes/apps/actions-runner-system/home-ops-runners/`.
+
+## Manual Upgrade Process (script)
+
+The steps below drive the upgrade from a workstation. They remain useful for
+recovery and one-off work, but the workflow above is the normal path.
+
+> **Note:** `upgrade-talos.sh` upgrades workers before the control plane, the
+> reverse of the workflow's order. Either is safe; the workflow's order matches
+> the usual Kubernetes convention of moving the control plane first.
 
 ### 1. Update Talos Version
 
@@ -128,23 +168,26 @@ talosctl get extensions --nodes 192.168.10.33
 
 ### Upgrade Order
 
-Always upgrade in this order to maintain cluster stability:
+Upgrade in this order to maintain cluster stability:
 
-1. **Worker nodes first** (can be done in parallel)
-2. **Control plane nodes last** (one at a time, wait for each to complete)
+1. **Control plane nodes first** (one at a time, wait for each to complete)
+2. **Worker nodes after** (one at a time, so capacity is never lost in bulk)
+
+This is the order the GitHub Actions workflow uses. `upgrade-talos.sh` predates
+it and does the reverse; both work, since the Talos version does not create
+kubelet version skew.
 
 Example:
 ```bash
-# Workers (all at once or in batches)
-for node in 192.168.10.{71..78}; do
-  talosctl upgrade --nodes $node --image factory.talos.dev/installer/SCHEMATIC:VERSION &
-done
-wait
-
 # Control plane (one at a time)
 talosctl upgrade --nodes 192.168.10.33 --image factory.talos.dev/installer/SCHEMATIC:VERSION --wait
 talosctl upgrade --nodes 192.168.10.44 --image factory.talos.dev/installer/SCHEMATIC:VERSION --wait
 talosctl upgrade --nodes 192.168.10.4 --image factory.talos.dev/installer/SCHEMATIC:VERSION --wait
+
+# Workers (one at a time)
+for node in 192.168.10.{71..78}; do
+  talosctl upgrade --nodes $node --image factory.talos.dev/installer/SCHEMATIC:VERSION --wait
+done
 ```
 
 ## Creating/Updating Schematics
@@ -306,8 +349,8 @@ After upgrading Talos:
 
 ## Important Notes
 
-- **Always upgrade workers before control plane**
-- **Upgrade control plane nodes one at a time**
+- **Upgrade the control plane first, then workers**
+- **Upgrade nodes one at a time**
 - **Wait for each control plane node to fully come up before upgrading the next**
 - **Test in non-production first if possible**
 - **Keep backups of etcd** (Talos handles this automatically, but verify)


### PR DESCRIPTION
Part B, on top of #542. Rolls the cluster one node at a time, each node its own job named after its hostname: the three control plane nodes first, then the eight Pi workers.

## Flow

`plan` → `approve` → `control-plane` (×3) → `workers` (×8) → `upgrade-k8s` → `verify`

- **Trigger** — a push to `main` touching `talos/talenv.yaml` (i.e. merging a Renovate installer bump), or manual dispatch with an optional `nodes` filter and `dry-run` toggle.
- **Approval** — `approve` is bound to the `talos-upgrade` environment, so a weekend Renovate merge waits for a reviewer. `plan` runs first and unconditionally, so the summary showing the target version and which nodes are behind is readable *before* approving.
- **One at a time** — `max-parallel: 1` within each phase, and `needs:` between them. `fail-fast: true` stops the rest on the first failure.

## Decisions worth flagging

**Live state, not the git diff.** Whether to run is decided by comparing each node's reported Talos version against `talenv.yaml`, not by diffing the commit. Two things fall out for free: a commit that only moves `kubernetesVersion` finds every node already on target and reboots nothing (it just runs `upgrade-k8s`), and a rerun after a failure skips the nodes that already made it. Resuming a partial rollout is just re-running the workflow.

**Endpoint steering.** `talosctl` is pointed at a control plane node *other* than the one being rebooted, so a job's own API calls never route through the machine it is taking down.

**Cordon handling.** `talosctl upgrade` cordons and drains the node itself (`--drain` defaults to true). The health gate uncordons afterward, but only if the node was not already cordoned when the job started — a deliberate cordon survives the run. Relatedly, preflight reads the `Ready` *condition* rather than the `STATUS` column, since the latter reports `Ready,SchedulingDisabled` and would otherwise block the very rerun meant to clean up after a failure.

**Shared per-node action.** The upgrade/gate logic lives in `.github/actions/talos-upgrade-node` so the control plane and worker phases don't carry two copies. Keeps job names flat, unlike a reusable workflow.

**Tool versions come from `.mise.toml`** at runtime rather than being re-pinned here, so Renovate keeps them current in one place. Tools are fetched directly rather than through `mise` itself, which would also pull python, aws, helm, cilium and the rest of the toolchain on every job.

## Health gate

Before releasing the next node, a job waits for the target version to be reported, the node to be `Ready`, and — control plane only — `etcd` to report `HEALTH OK`. 15 minute gate, 25 minute `talosctl` timeout, 45 minute job timeout.

## Verified

Against the live cluster, since most of this is shell: matrix construction from `talconfig.yaml` (including the `nodes` filter, preserving CP-then-worker order), the `Talos (v1.13.6)` osImage parse, server-tag extraction from `talosctl version --short` (the naive `grep Tag:` reads the *client* version — `upgrade-talos.sh` has that bug), etcd health parsing, and the preflight and verify loops. `talhelper genconfig` was confirmed to need only the age key — no `sops` binary — and `gencommand upgrade` to resolve the right per-node factory schematic.

Not yet exercised end to end: no runner has picked up a job, because the pools from #542 are currently blocked (see below).

## Blocked on a permission

The runner pools from #542 have no listener pods. The ARC controller is authenticating fine but getting 403 on token issuance:

```
POST https://api.github.com/repos/casmith/home-ops/actions/runners/registration-token
failed(status="403 Forbidden"): Resource not accessible by integration
```

A 403 rather than a 404 means the App is installed on the repo but is missing **Administration: Read and write**, which ARC needs to mint runner registration tokens. Adding it to the App and accepting the updated permissions on the installation should be enough; the controller retries on its own every ~16 minutes.

Until that clears, no job in this workflow can start.

## Also

`talos/UPGRADE.md` documents the workflow and its ordering. The doc previously said "always upgrade workers before control plane" while this workflow does the reverse; the doc now states control-plane-first and notes that `upgrade-talos.sh` still does workers-first, so the discrepancy isn't a trap for anyone reading both.