### PR TITLE
fix(talos): survive the Longhorn failure modes seen on the first run

### DIFF
--- a/.github/actions/talos-setup/action.yaml
+++ b/.github/actions/talos-setup/action.yaml
@@ -58,13 +58,18 @@ runs:
 
         echo "talosctl v${talos_version}, talhelper v${talhelper_version}, yq v${yq_version}, kubectl v${kubectl_version} (${arch})"
 
-        curl -fsSL -o "${bin}/talosctl" \
+        # These runners are pods in the cluster being upgraded, so cluster DNS
+        # can blip underneath them while a node reboots. Retry rather than fail
+        # a whole node's job on a transient resolver error.
+        fetch() { curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "$@"; }
+
+        fetch -o "${bin}/talosctl" \
           "https://github.com/siderolabs/talos/releases/download/v${talos_version}/talosctl-linux-${arch}"
-        curl -fsSL "https://github.com/budimanjojo/talhelper/releases/download/v${talhelper_version}/talhelper_linux_${arch}.tar.gz" \
+        fetch "https://github.com/budimanjojo/talhelper/releases/download/v${talhelper_version}/talhelper_linux_${arch}.tar.gz" \
           | tar -xz -C "$bin" talhelper
-        curl -fsSL -o "${bin}/yq" \
+        fetch -o "${bin}/yq" \
           "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_linux_${arch}"
-        curl -fsSL -o "${bin}/kubectl" \
+        fetch -o "${bin}/kubectl" \
           "https://dl.k8s.io/release/v${kubectl_version}/bin/linux/${arch}/kubectl"
 
         chmod +x "${bin}"/*

--- a/.github/actions/talos-upgrade-node/action.yaml
+++ b/.github/actions/talos-upgrade-node/action.yaml
@@ -82,10 +82,15 @@ runs:
         # talhelper resolves the correct factory schematic for this node and the
         # version from talenv.yaml. talosctl cordons and drains the node itself
         # (--drain defaults to true) and waits for it to come back (--wait).
+        #
+        # The timeout is deliberately short. The two failures seen in practice --
+        # a drain blocked by a Longhorn instance-manager PDB, and an unmount
+        # wedged on an unreachable Longhorn NFS share -- never recover on their
+        # own, so a long timeout only delays a failure that is already certain.
         cd talos
         talhelper gencommand upgrade \
           --node "$IP" \
-          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=25m" \
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=12m" \
           | tee /dev/stderr \
           | bash
 
@@ -100,7 +105,7 @@ runs:
         echo "Would run:"
         talhelper gencommand upgrade \
           --node "$IP" \
-          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=25m"
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=12m"
 
     - name: Wait for healthy
       if: steps.current.outputs.skip == 'false' && inputs.dry-run != 'true'
@@ -163,6 +168,55 @@ runs:
           kubectl uncordon "$HOSTNAME_"
         else
           echo "${HOSTNAME_} was cordoned before this run; leaving it cordoned"
+        fi
+
+    - name: Diagnose failure
+      if: failure()
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        # Never mask the real failure: this step is diagnostics only.
+        set +e
+
+        echo "::group::Talos service states on ${HOSTNAME_}"
+        talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" services 2>&1 | head -20
+        echo "::endgroup::"
+
+        # The tail of the machine log is what distinguishes the known failure
+        # modes: a blocked drain never reaches stopServices, while a wedged
+        # unmount sits in the umount phase logging NFS timeouts.
+        echo "::group::Last machine log lines on ${HOSTNAME_}"
+        talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" dmesg 2>&1 | tail -20
+        echo "::endgroup::"
+
+        echo "::group::Node status"
+        kubectl get node "$HOSTNAME_" -o wide 2>&1
+        echo "::endgroup::"
+
+    - name: Restore cordon state
+      if: failure()
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+        WAS_CORDONED: ${{ steps.cordon.outputs.was-cordoned }}
+      run: |
+        set +e
+
+        # A failed upgrade leaves the node cordoned by talosctl's drain. Undo
+        # that, or the node sits unschedulable until someone notices -- and a
+        # rerun will not fix it, because a node already on the target version is
+        # skipped before it reaches the uncordon in the health gate.
+        if [[ "$WAS_CORDONED" == "true" ]]; then
+          echo "${HOSTNAME_} was cordoned before this run; leaving it cordoned"
+          exit 0
+        fi
+
+        cordoned="$(kubectl get node "$HOSTNAME_" -o jsonpath='{.spec.unschedulable}' 2>/dev/null)"
+        if [[ "$cordoned" == "true" ]]; then
+          echo "::warning::${HOSTNAME_} was left cordoned by the failed upgrade; uncordoning"
+          kubectl uncordon "$HOSTNAME_"
         fi
 
     - name: Summary

--- a/talos/UPGRADE.md
+++ b/talos/UPGRADE.md
@@ -72,6 +72,65 @@ Pis) and worker jobs on `home-ops-runners-amd64` (the control plane). Without
 that split, a job would eventually evict itself. See
 `kubernetes/apps/actions-runner-system/home-ops-runners/`.
 
+### Longhorn interactions (read this before upgrading)
+
+Both failures seen on the first real run came from Longhorn, and neither is a
+workflow bug. Expect them until the drain policy is changed.
+
+**1. The drain is refused, not slow.** Longhorn gives each `instance-manager`
+pod a PodDisruptionBudget. With `node-drain-policy: block-if-contains-last-replica`
+those PDBs report `ALLOWED DISRUPTIONS: 0`, so `talosctl upgrade`'s built-in
+drain can never evict them and fails after `--drain-timeout`:
+
+```
+error draining node "k8s-cp-3": error when evicting pods/"instance-manager-..."
+-n "longhorn-system": client rate limiter Wait returned an error
+```
+
+Raising the timeout does not help. Check the policy and the budgets with:
+
+```bash
+kubectl -n longhorn-system get settings.longhorn.io node-drain-policy -o jsonpath='{.value}'
+kubectl -n longhorn-system get pdb
+```
+
+Note that `allow-if-replica-is-stopped` does **not** help while replicas are
+running, which is the normal case. Only `always-allow` (or moving replicas off
+the node first) unblocks it.
+
+**2. The unmount can wedge after the drain succeeds.** Longhorn serves RWX
+volumes over NFS from a share-manager pod reachable only by ClusterIP. During an
+upgrade Talos stops `cri` -- taking the Cilium datapath with it -- and *then*
+unmounts pod volumes. A leftover Longhorn CSI `globalmount` therefore points at
+an NFS server the node can no longer route to, and the unmount hangs forever:
+
+```
+task unmountPodMounts (1/1): unmounting .../csi/driver.longhorn.io/.../globalmount
+nfs: server 10.43.x.x not responding, timed out
+```
+
+The node sits before the install step, still on the old version, with `etcd`,
+`kubelet` and `cri` stopped. It does not recover on its own. Free it with:
+
+```bash
+talosctl -n <node-ip> -e <other-cp-ip> reboot --mode powercycle
+```
+
+There is no way to predict this from outside the node: the mounts that wedge
+look identical to the ones every healthy node carries while running RWX
+workloads. Diagnose it from the machine log:
+
+```bash
+talosctl -n <node-ip> -e <other-cp-ip> dmesg | tail -20
+talosctl -n <node-ip> -e <other-cp-ip> services
+```
+
+**Recovering a halted rollout.** `fail-fast` stops the remaining nodes, so the
+cluster is left partly upgraded but stable. Fix the cause, then re-run the
+workflow: nodes already on the target version are skipped, so it resumes rather
+than restarting. Check for a node left cordoned first (`kubectl get nodes`) --
+the workflow uncordons on failure, but not if its runner was killed outright.
+
 ## Manual Upgrade Process (script)
 
 The steps below drive the upgrade from a workstation. They remain useful for


### PR DESCRIPTION
The first real rollout (run [30974150392](https://github.com/casmith/home-ops/actions/runs/30974150392)) upgraded `k8s-cp-1` and `k8s-cp-2` to v1.13.8, then hit two distinct Longhorn interactions. Neither is a workflow bug, but the workflow handled both worse than it should have.

## What happened

**`k8s-cp-2` wedged mid-upgrade.** Talos stops `cri` — taking the Cilium datapath with it — and *then* unmounts pod volumes. A leftover Longhorn CSI `globalmount` pointed at an RWX share-manager reachable only by ClusterIP, so the unmount hung forever:

```
task unmountPodMounts (1/1): unmounting .../csi/driver.longhorn.io/.../globalmount
nfs: server 10.43.44.34 not responding, timed out
```

It sat before the install step with `etcd`/`kubelet`/`cri` stopped, and recovered only via `talosctl reboot --mode powercycle`.

**`k8s-cp-3` failed at the drain**, before any upgrade was issued:

```
error draining node "k8s-cp-3": error when evicting pods/"instance-manager-..."
-n "longhorn-system": client rate limiter Wait returned an error
```

Longhorn's `instance-manager` PDBs report `ALLOWED DISRUPTIONS: 0` under `node-drain-policy: block-if-contains-last-replica`. The eviction is *refused*, not slow — no timeout value would have helped.

## Changes

- **Timeout 25m → 12m.** Both failure modes are permanent; a long timeout only delays a certain failure.
- **Uncordon on the failure path.** `talosctl`'s drain cordons before failing, and a rerun cannot repair it — a node already on target is skipped before reaching the uncordon in the health gate. cp-3 stayed unschedulable until fixed by hand.
- **Failure diagnostics.** Dump Talos service states and the machine log tail. That tail is what distinguishes the two modes: a blocked drain never reaches `stopServices`, a wedged unmount sits in `umount` logging NFS timeouts.
- **Retry tool downloads.** The runners are pods in the cluster being upgraded, so cluster DNS blips underneath them while a node reboots. Already observed once, on the `Approve` job.
- **`UPGRADE.md`** documents both failure modes, how to tell them apart, the power-cycle recovery, and how to resume a halted rollout.

## What I deliberately did not add

A pre-flight check for Longhorn NFS mounts, which I'd proposed. The data kills it:

| node | outcome | longhorn/nfs mounts |
|---|---|---|
| `k8s-cp-1` | upgraded cleanly | 11 |
| `k8s-cp-2` | wedged, then upgraded | 10 |
| `k8s-cp-3` | failed at drain | **0** |

Those mounts are the normal steady state for any node running RWX workloads. A gate on them blocks healthy nodes and misses the one that actually failed. The wedge only materialises after `cri` stops, which isn't observable from outside the node.

## Still required before a full rollout

This PR makes failures fast, self-cleaning and diagnosable — it does **not** make the drain succeed. `k8s-cp-3` and all eight Pi workers will still fail on the instance-manager PDB until `node-drain-policy` changes. That's a separate PR, since it's a storage-availability decision: all 24 volumes are 3-replica with no single-replica volumes, so `always-allow` leaves 2 of 3 replicas online with one node down at a time.

Suggested order: merge this, change the drain policy, then retry against a single Pi (`nodes: k8s-pi-8`) before the rest.