### PR TITLE
feat(longhorn): set node-drain-policy to always-allow

### DIFF
--- a/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
@@ -71,6 +71,21 @@ spec:
       # (max 3/node, live + health-checked). Keeps stale engine-image
       # DaemonSets from piling up on every node. 0 = disabled (the default).
       concurrentAutomaticEngineUpgradePerNodeLimit: 3
+      # Required for Talos node upgrades to drain at all. Longhorn gives every
+      # instance-manager pod a PDB with minAvailable 1, and there is exactly one
+      # such pod per node, so under the default block-if-contains-last-replica
+      # every node reports ALLOWED DISRUPTIONS: 0 — including nodes hosting no
+      # replicas. The eviction is refused outright rather than being slow, so no
+      # drain timeout helps; talosctl upgrade fails on every node. This took out
+      # k8s-cp-3 on the first automated rollout (see talos/UPGRADE.md).
+      #
+      # allow-if-replica-is-stopped is not a usable middle ground here: it still
+      # blocks while replicas are running, which is the normal state.
+      #
+      # Acceptable risk: 23 of 24 volumes are 3-replica (the 24th is an orphaned
+      # detached clone with no PV), and the upgrade workflow takes one node down
+      # at a time, so a volume drops to 2 of 3 replicas at worst.
+      nodeDrainPolicy: always-allow
     longhornUI:
       replicas: 1  # built-in UI; exposed via HTTPRoute, not the chart ingress
     ingress:


### PR DESCRIPTION
Split out from #544 so the workflow fixes can merge without this storage-availability decision.

## Why

Longhorn gives every `instance-manager` pod a PDB with `minAvailable: 1`, and there is exactly one such pod per node. Under the default `block-if-contains-last-replica`, **all 11 nodes** report `ALLOWED DISRUPTIONS: 0`:

```
instance-manager-049f4410840cbd0b6474975daf80b10f   0    (k8s-cp-2)
instance-manager-133a9ec357ad04f728983ae219f2545c   0    (k8s-pi-8)
instance-manager-22f4f9de175906292f24a7feae0874f6   0    (k8s-pi-4)
...all 11 identical
```

That includes `k8s-pi-1` through `k8s-pi-4`, which host **zero** replicas. So this isn't Longhorn protecting data on specific nodes — no node in this cluster can be drained at all.

This is what killed `k8s-cp-3` on the first automated rollout:

```
error draining node "k8s-cp-3": error when evicting pods/"instance-manager-..."
-n "longhorn-system": client rate limiter Wait returned an error
```

The eviction is *refused*, not slow, so `talosctl upgrade`'s built-in drain fails regardless of `--drain-timeout`.

## Why not the safer-sounding option

`allow-if-replica-is-stopped` looks like the conservative middle ground but is useless here — it still blocks while replicas are running, which is the normal state. I recommended it before checking, and the replica states disprove it.

`block-for-eviction` would rebuild every replica off a node before draining it: roughly 20 volumes rebuilt per node across 11 nodes on Pi hardware. Correct in theory, impractical as a routine upgrade path.

## Risk

Bounded, and I checked rather than assumed:

- **23 of 24 volumes are 3-replica.** The 24th (`cloned-pvc-71c78db9-...`) is an orphaned clone: detached, replica stopped, no PersistentVolume backing it.
- **Zero single-replica volumes** by spec (`numberOfReplicas: 1` returns nothing).
- **20 healthy, 4 `unknown`** — all four `unknown` are simply detached, not degraded.
- The upgrade workflow takes **one node down at a time**, so a volume drops to 2 of 3 replicas at worst.

The tradeoff being accepted: if a volume ever *is* down to its last replica, a drain will no longer protect it. Given 3× replication and serialized upgrades, that window is narrow — but it is a real reduction in Longhorn's safety net, which is why this is its own PR.

## Note on an existing comment

The `createDefaultDiskLabeledNodes` comment above says replicas live on "the amd64 cp nodes". Live state disagrees — replicas currently sit on `k8s-cp-3` (24), `k8s-pi-5` (22), `k8s-pi-6` (17), `k8s-pi-7` (4) and `k8s-pi-8` (3), with none on cp-1 or cp-2. Some of that is fallout from the partial rollout rebuilding replicas, but the comment looks stale. Not touching it here; worth a look separately.

## After merging

Flux reconciles the HelmRelease and longhorn-manager applies the setting on start. Verify with:

```bash
kubectl -n longhorn-system get settings.longhorn.io node-drain-policy -o jsonpath='{.value}'
kubectl -n longhorn-system get pdb | grep instance-manager
```

Expect the value to read `always-allow` and the instance-manager PDBs to allow a disruption. Only then is a retry worth attempting.