### PR TITLE
fix(talos): drain workloads before the instance manager

### DIFF
--- a/.github/actions/talos-upgrade-node/action.yaml
+++ b/.github/actions/talos-upgrade-node/action.yaml
@@ -71,6 +71,52 @@ runs:
         was_cordoned="$(kubectl get node "$HOSTNAME_" -o jsonpath='{.spec.unschedulable}')"
         echo "was-cordoned=${was_cordoned:-false}" >> "$GITHUB_OUTPUT"
 
+    - name: Drain workloads
+      if: steps.current.outputs.skip == 'false' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+
+        # Longhorn guards each instance-manager pod with a PodDisruptionBudget
+        # for as long as that manager runs engines for attached volumes, and it
+        # is the workload pods on this node that keep those engines alive.
+        # talosctl's own drain evicts workloads and the instance manager in a
+        # single pass, so the manager's eviction is refused while its engines
+        # are still up and the drain fails outright -- see talos/UPGRADE.md.
+        #
+        # Draining the workloads first breaks that circle. The `!=` selector
+        # spares the instance manager: label selectors also match objects that
+        # lack the key entirely, so ordinary workload pods are still evicted.
+        kubectl drain "$HOSTNAME_" \
+          --ignore-daemonsets \
+          --delete-emptydir-data \
+          --pod-selector='longhorn.io/component!=instance-manager' \
+          --timeout=10m
+
+        # With the workloads gone the volumes detach, the engine count falls to
+        # zero, and Longhorn removes the PDB by itself -- no drain-policy
+        # override required. Measured at roughly two seconds on k8s-pi-8.
+        count_engines() {
+          kubectl -n longhorn-system get engines.longhorn.io \
+            -o jsonpath="{range .items[?(@.spec.nodeID==\"${HOSTNAME_}\")]}{.metadata.name}{\"\n\"}{end}" \
+            2>/dev/null | grep -c . || true
+        }
+
+        deadline=$(( SECONDS + 300 ))
+        while [[ "$(count_engines)" != "0" ]]; do
+          if (( SECONDS > deadline )); then
+            echo "::error::Longhorn engines are still running on ${HOSTNAME_}; the instance-manager PDB will block the upgrade"
+            kubectl -n longhorn-system get pdb 2>&1 | grep instance-manager || true
+            exit 1
+          fi
+          echo "  waiting for Longhorn engines to leave ${HOSTNAME_} ($(count_engines) remaining)"
+          sleep 10
+        done
+
+        echo "No Longhorn engines remain on ${HOSTNAME_}"
+
     - name: Upgrade
       if: steps.current.outputs.skip == 'false' && inputs.dry-run != 'true'
       shell: bash
@@ -80,17 +126,21 @@ runs:
         set -euo pipefail
 
         # talhelper resolves the correct factory schematic for this node and the
-        # version from talenv.yaml. talosctl cordons and drains the node itself
-        # (--drain defaults to true) and waits for it to come back (--wait).
+        # version from talenv.yaml.
         #
-        # The timeout is deliberately short. The two failures seen in practice --
+        # --drain=false because the node was drained in the previous step.
+        # Leaving talosctl to drain would reintroduce the single-pass eviction
+        # this action exists to avoid. It also means talosctl no longer
+        # uncordons on success, so the health gate below does it instead.
+        #
+        # The timeout is deliberately short. The failures seen in practice --
         # a drain blocked by a Longhorn instance-manager PDB, and an unmount
         # wedged on an unreachable Longhorn NFS share -- never recover on their
         # own, so a long timeout only delays a failure that is already certain.
         cd talos
         talhelper gencommand upgrade \
           --node "$IP" \
-          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=12m" \
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=12m --drain=false" \
           | tee /dev/stderr \
           | bash
 
@@ -102,10 +152,11 @@ runs:
       run: |
         set -euo pipefail
         cd talos
-        echo "Would run:"
+        echo "Would drain workloads off ${{ inputs.hostname }}, wait for Longhorn"
+        echo "engines to leave it, then run:"
         talhelper gencommand upgrade \
           --node "$IP" \
-          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=12m"
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --timeout=12m --drain=false"
 
     - name: Wait for healthy
       if: steps.current.outputs.skip == 'false' && inputs.dry-run != 'true'
@@ -162,8 +213,10 @@ runs:
           wait_for "etcd on ${HOSTNAME_} to be healthy" etcd_healthy
         fi
 
-        # talosctl cordons the node as part of the drain. Undo that unless the
-        # node was already cordoned before this job started.
+        # The drain step cordoned the node. Undo that unless it was already
+        # cordoned before this job started, so a deliberate operator cordon is
+        # preserved. This is load-bearing now that the upgrade runs with
+        # --drain=false: talosctl only uncordons nodes it cordoned itself.
         if [[ "$WAS_CORDONED" != "true" ]]; then
           kubectl uncordon "$HOSTNAME_"
         else

--- a/talos/UPGRADE.md
+++ b/talos/UPGRADE.md
@@ -77,26 +77,45 @@ that split, a job would eventually evict itself. See
 Both failures seen on the first real run came from Longhorn, and neither is a
 workflow bug. Expect them until the drain policy is changed.
 
-**1. The drain is refused, not slow.** Longhorn gives each `instance-manager`
-pod a PodDisruptionBudget. With `node-drain-policy: block-if-contains-last-replica`
-those PDBs report `ALLOWED DISRUPTIONS: 0`, so `talosctl upgrade`'s built-in
-drain can never evict them and fails after `--drain-timeout`:
+**1. The drain is refused, not slow.** Longhorn guards each `instance-manager`
+pod with a PodDisruptionBudget for as long as that manager runs engines for
+attached volumes. Those PDBs report `ALLOWED DISRUPTIONS: 0`, so a drain that
+tries to evict the instance manager fails outright:
 
 ```
 error draining node "k8s-cp-3": error when evicting pods/"instance-manager-..."
 -n "longhorn-system": client rate limiter Wait returned an error
 ```
 
-Raising the timeout does not help. Check the policy and the budgets with:
+Raising the timeout does not help — the eviction is refused, not slow.
+
+**This is an ordering problem, not a policy one.** It is the workload pods on
+the node that keep those engines alive, and `talosctl upgrade` evicts the
+workloads and the instance manager in a single pass, so the manager is still
+serving engines at the moment it is asked to leave. The workflow therefore
+drains in two phases, and upgrades with `--drain=false`:
+
+```bash
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data \
+  --pod-selector='longhorn.io/component!=instance-manager' --timeout=10m
+# engines fall to zero, Longhorn removes the PDB by itself
+talosctl upgrade --nodes <ip> --image ... --drain=false
+```
+
+Measured on `k8s-pi-8`: engines reached zero and the PDB disappeared within
+ten seconds of the workload drain, and the subsequent Talos drain took two
+seconds — against five minutes of failure on `k8s-cp-3`.
+
+Changing `node-drain-policy` does **not** fix this. `always-allow` was tried:
+Longhorn recreated the deleted PDB within 15 seconds while that policy was
+active, because the instance manager still had running engines.
+`allow-if-replica-is-stopped` is no better, since it blocks while replicas are
+running, which is the normal state. Inspect the current state with:
 
 ```bash
 kubectl -n longhorn-system get settings.longhorn.io node-drain-policy -o jsonpath='{.value}'
-kubectl -n longhorn-system get pdb
+kubectl -n longhorn-system get pdb | grep instance-manager
 ```
-
-Note that `allow-if-replica-is-stopped` does **not** help while replicas are
-running, which is the normal case. Only `always-allow` (or moving replicas off
-the node first) unblocks it.
 
 **2. The unmount can wedge after the drain succeeds.** Longhorn serves RWX
 volumes over NFS from a share-manager pod reachable only by ClusterIP. During an
@@ -124,6 +143,13 @@ workloads. Diagnose it from the machine log:
 talosctl -n <node-ip> -e <other-cp-ip> dmesg | tail -20
 talosctl -n <node-ip> -e <other-cp-ip> services
 ```
+
+**Cordons are the workflow's responsibility now.** Because the upgrade runs with
+`--drain=false`, `talosctl` no longer cordons or uncordons anything — the
+workflow's own drain step cordons, and the health gate uncordons after the node
+is healthy. A node cordoned *before* the run is left cordoned deliberately. If a
+job dies outright (its runner evicted, say) the node can be left cordoned with
+no one to undo it, so check `kubectl get nodes` after any failed run.
 
 **Recovering a halted rollout.** `fail-fast` stops the remaining nodes, so the
 cluster is left partly upgraded but stable. Fix the cause, then re-run the


### PR DESCRIPTION
The last piece needed for the rollout to finish. `k8s-pi-8` was upgraded successfully by doing this by hand; this puts it in the workflow.

## The actual mechanism

Longhorn guards each `instance-manager` pod with a PDB for as long as that manager runs engines for attached volumes — and it is the **workload pods on the node** that keep those engines alive. `talosctl upgrade` evicts the workloads and the instance manager in a single pass, so the manager is still serving engines at the moment it is asked to leave. The eviction is refused and the drain fails. That is what stopped `k8s-cp-3`.

Drain the workloads first and the circle breaks on its own:

```
kubectl drain ... --pod-selector='longhorn.io/component!=instance-manager'
  → engines fall to 0
  → Longhorn removes the PDB itself
  → talosctl drain succeeds in 2 seconds
```

The `!=` selector is the load-bearing detail: Kubernetes label selectors also match objects that lack the key entirely, so ordinary workload pods are still evicted while the instance manager is spared.

## Measured on k8s-pi-8

| | |
|---|---|
| workload drain | 14 pods evicted, node drained |
| engines → 0 and PDB gone | within 10 seconds |
| subsequent Talos drain | **2 seconds** (vs 5 min of failure on cp-3) |
| result | v1.13.8, Ready, workloads rescheduled back |

## This corrects #545

`always-allow` does **not** fix this, and I said it would. Deleting pi-8's PDB with that policy active, Longhorn recreated it within 15 seconds — because the instance manager still had running engines. The drain policy was never the blocker.

I have not reverted #545 here, since that is a separate change and worth confirming empirically first: with a proper workload drain, `block-if-contains-last-replica` should not re-block either, because engines are gone and every volume has 3 replicas. Suggest reverting it after the next node upgrades cleanly, rather than leaving Longhorn's last-replica guard disabled on the strength of reasoning that has already been wrong once.

## Cordon handling, corrected

With `--drain=false`, `talosctl` no longer cordons or uncordons anything. That makes the health gate's uncordon load-bearing rather than the dead code it had quietly become — the pi-8 logs showed `talosctl` uncordoning the node itself, then the gate printing `leaving it cordoned` about a node that was already schedulable. The comment claiming talosctl "cordons as part of the drain" was half right: it also uncordoned, unconditionally, so a deliberate operator cordon did not actually survive an upgrade. It does now.

`UPGRADE.md` gets the mechanism, the measurements, why the drain-policy approaches fail, and a note that a job killed outright can still leave a node cordoned with no one to undo it.

## Not addressed

The `k8s-cp-2` RWX/NFS unmount wedge. It may well be prevented by this change — the workload pods and their mounts now leave before Talos stops CRI — but that is a hypothesis, not a result. The recovery procedure stays documented.

## Suggested next step

Dispatch a single node — `k8s-pi-7` — before the remaining seven. If its drain completes in seconds like pi-8's did, run the rest.