### PR TITLE
Revert "feat(longhorn): set node-drain-policy to always-allow"

### DIFF
--- a/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn/longhorn-system/app/helmrelease.yaml
@@ -71,21 +71,6 @@ spec:
       # (max 3/node, live + health-checked). Keeps stale engine-image
       # DaemonSets from piling up on every node. 0 = disabled (the default).
       concurrentAutomaticEngineUpgradePerNodeLimit: 3
-      # Required for Talos node upgrades to drain at all. Longhorn gives every
-      # instance-manager pod a PDB with minAvailable 1, and there is exactly one
-      # such pod per node, so under the default block-if-contains-last-replica
-      # every node reports ALLOWED DISRUPTIONS: 0 — including nodes hosting no
-      # replicas. The eviction is refused outright rather than being slow, so no
-      # drain timeout helps; talosctl upgrade fails on every node. This took out
-      # k8s-cp-3 on the first automated rollout (see talos/UPGRADE.md).
-      #
-      # allow-if-replica-is-stopped is not a usable middle ground here: it still
-      # blocks while replicas are running, which is the normal state.
-      #
-      # Acceptable risk: 23 of 24 volumes are 3-replica (the 24th is an orphaned
-      # detached clone with no PV), and the upgrade workflow takes one node down
-      # at a time, so a volume drops to 2 of 3 replicas at worst.
-      nodeDrainPolicy: always-allow
     longhornUI:
       replicas: 1  # built-in UI; exposed via HTTPRoute, not the chart ingress
     ingress:


### PR DESCRIPTION
Reverts #545, which was based on a diagnosis that turned out to be wrong.

## Why

`always-allow` does not clear Longhorn's instance-manager PDBs. With that policy active, I deleted pi-8's PDB and **Longhorn recreated it within 15 seconds**, still reporting `ALLOWED DISRUPTIONS: 0` — because the instance manager was still running engines for attached volumes. The drain policy was never the blocker.

The real cause was ordering, and it's fixed in #546: the workload pods on a node are what keep its engines alive, and `talosctl upgrade` evicted the workloads and the instance manager in a single pass. Drain the workloads first and the engine count drops to zero, at which point **Longhorn removes the PDB on its own**.

Measured on `k8s-pi-8`:

| step | time |
|---|---|
| engines → 0 and PDB removed after workload drain | ~10s |
| Talos drain that followed | **2s** |
| (for comparison) blocked drain on `k8s-cp-3` | 5 min, then failure |

## What this costs

Nothing. `always-allow` buys no benefit now that the ordering is right, and it permanently disabled Longhorn's last-replica guard — a safety net worth keeping on a cluster with no volume backups, no Longhorn backup target, and `local-path` PVs that have no redundancy at all.

## After merging

Removing the value from the chart does **not** necessarily reset the live Setting: `longhorn-manager` only applies customized values it is given, so an existing `Setting` CR can persist at its old value. Verify after reconcile:

```bash
kubectl -n longhorn-system get settings.longhorn.io node-drain-policy -o jsonpath='{.value}'
```

If it still reads `always-allow`, set it back explicitly to `block-if-contains-last-replica`. I'll check once Flux has reconciled.