### PR TITLE
fix(talos): stop SIGPIPE from failing the upgrade jobs

### DIFF
--- a/.github/actions/talos-setup/action.yaml
+++ b/.github/actions/talos-setup/action.yaml
@@ -100,9 +100,15 @@ runs:
 
         # Route API calls through a control plane node other than the one this
         # job is about to reboot.
+        #
+        # Selection happens inside yq rather than piping to `head -1`: head
+        # closes the pipe after the first line, yq takes SIGPIPE, and pipefail
+        # turns that into exit 141. It is a race -- yq usually finishes writing
+        # three short lines first -- so it passed for several runs before
+        # failing a dispatch outright.
         ip="$(yq eval -r \
-          ".nodes[] | select(.controlPlane == true) | select(.ipAddress != \"${EXCLUDE_IP}\") | .ipAddress" \
-          talos/talconfig.yaml | head -1)"
+          "[.nodes[] | select(.controlPlane == true) | select(.ipAddress != \"${EXCLUDE_IP}\") | .ipAddress] | .[0] // \"\"" \
+          talos/talconfig.yaml)"
 
         if [[ -z "$ip" ]]; then
           echo "::error::no control plane node available as an endpoint (excluding ${EXCLUDE_IP})"

--- a/.github/actions/talos-upgrade-node/action.yaml
+++ b/.github/actions/talos-upgrade-node/action.yaml
@@ -40,7 +40,7 @@ runs:
         # The first "Tag:" belongs to the client, so only read the one that
         # follows the Server: header.
         current="$(talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" version --short \
-          | awk '/^Server:/ { server = 1 } server && $1 == "Tag:" { print $2; exit }')" || true
+          | awk '/^Server:/ { server = 1 } server && $1 == "Tag:" { print $2 }')" || true
 
         if [[ -z "$current" ]]; then
           echo "::error::could not determine the Talos version running on $IP"
@@ -188,7 +188,7 @@ runs:
         at_target_version() {
           local current
           current="$(talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" version --short 2>/dev/null \
-            | awk '/^Server:/ { server = 1 } server && $1 == "Tag:" { print $2; exit }')" || return 1
+            | awk '/^Server:/ { server = 1 } server && $1 == "Tag:" { print $2 }')" || return 1
           [[ "$current" == "$TARGET" ]]
         }
 
@@ -202,7 +202,7 @@ runs:
         etcd_healthy() {
           local health
           health="$(talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" service etcd 2>/dev/null \
-            | awk '$1 == "HEALTH" { print $2; exit }')" || return 1
+            | awk '$1 == "HEALTH" { print $2 }')" || return 1
           [[ "$health" == "OK" ]]
         }
 

--- a/.github/workflows/talos-upgrade.yaml
+++ b/.github/workflows/talos-upgrade.yaml
@@ -71,8 +71,10 @@ jobs:
           fi
 
           while read -r hostname ip; do
+            # No `exit` in the awk: quitting early closes the pipe, talosctl
+            # takes SIGPIPE, and pipefail turns that into a failed preflight.
             health="$(talosctl --nodes "$ip" --endpoints "$TALOS_ENDPOINT" service etcd \
-              | awk '$1 == "HEALTH" { print $2; exit }')"
+              | awk '$1 == "HEALTH" { print $2 }')"
             if [[ "$health" != "OK" ]]; then
               echo "::error::etcd on ${hostname} reports health ${health:-unknown}"
               exit 1


### PR DESCRIPTION
The `k8s-pi-7` dispatch ([run 31020461037](https://github.com/casmith/home-ops/actions/runs/31020461037)) failed in `Plan` before reaching the approval gate or touching any node. Exit code **141 = 128 + 13 = SIGPIPE**.

## Cause

```bash
ip="$(yq eval -r "..." talos/talconfig.yaml | head -1)"
```

`head -1` closes the pipe after the first line, `yq` is killed by SIGPIPE, and `set -o pipefail` promotes that into a failed step.

It's a **race**, which is why it hid so well: `yq` usually finishes writing three short lines into the pipe buffer before `head` exits. This exact code passed a dry run, the full control plane rollout, and the `k8s-pi-8` upgrade before failing a dispatch outright. Locally it passes 3/3 on demand.

## Fix

Do the selection inside `yq` so there is no pipe to break:

```yaml
"[.nodes[] | select(.controlPlane == true) | select(.ipAddress != \"${EXCLUDE_IP}\") | .ipAddress] | .[0] // \"\""
```

Verified for both the empty and excluded cases:

| exclude | result |
|---|---|
| `""` | `192.168.10.33` |
| `192.168.10.33` | `192.168.10.44` |

## The same bug, four more times

Any `awk ... { print; exit }` closes the pipe on `talosctl` identically:

- **`Preflight`'s etcd check** — unguarded, would have failed a run the same way
- **Three in `talos-upgrade-node`** — masked by `|| true` / `|| return 1`. Masked, not fixed, and those guards were also swallowing genuine `talosctl` failures

Dropping the early `exit`s removes the SIGPIPE source, so the remaining guards mean only "talosctl failed" rather than doubling as accidental SIGPIPE suppression.

## Verified against the live cluster

```
version parse (no exit):  lines=1  value=[v1.13.6]
etcd health parse:        lines=1  value=[OK]
pipefail safety:          no SIGPIPE
```

Single-line results either way, since there is exactly one `Tag:` under `Server:` and one `HEALTH` line per node.

## Note

This is a bug in code I wrote, not a cluster problem. `k8s-pi-7` was untouched — the run failed in `Plan`, so nothing was drained, cordoned or rebooted. Re-dispatch after merging.