### PR TITLE
fix(talos): let a kubernetesVersion-only bump actually upgrade Kubernetes

### DIFF
--- a/.github/workflows/talos-upgrade.yaml
+++ b/.github/workflows/talos-upgrade.yaml
@@ -32,8 +32,10 @@ jobs:
     timeout-minutes: 15
     outputs:
       should-run: ${{ steps.plan.outputs.should-run }}
+      nodes-pending: ${{ steps.plan.outputs.nodes-pending }}
       talos-version: ${{ steps.plan.outputs.talos-version }}
       upgrade-k8s: ${{ steps.plan.outputs.upgrade-k8s }}
+      k8s-version: ${{ steps.plan.outputs.k8s-version }}
       control-plane-matrix: ${{ steps.plan.outputs.control-plane-matrix }}
       worker-matrix: ${{ steps.plan.outputs.worker-matrix }}
       target-hostnames: ${{ steps.plan.outputs.target-hostnames }}
@@ -141,19 +143,30 @@ jobs:
             fi
           done < <(kubectl get nodes -o custom-columns='NAME:.metadata.name,IMAGE:.status.nodeInfo.osImage' --no-headers)
 
+          nodes_pending=false
           if (( ${#pending[@]} > 0 )); then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            nodes_pending=true
           fi
+          echo "nodes-pending=${nodes_pending}" >> "$GITHUB_OUTPUT"
 
           # Same idea for Kubernetes: compare the running kubelets, not the diff.
+          upgrade_k8s=false
           stale_kubelets="$(kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.kubeletVersion}' \
             | tr ' ' '\n' | grep -vx "$k8s_target" || true)"
           if [[ -n "$stale_kubelets" ]]; then
-            echo "upgrade-k8s=true" >> "$GITHUB_OUTPUT"
+            upgrade_k8s=true
+          fi
+          echo "upgrade-k8s=${upgrade_k8s}" >> "$GITHUB_OUTPUT"
+          echo "k8s-version=${k8s_target}" >> "$GITHUB_OUTPUT"
+
+          # should-run means "there is work to do", of either kind. Deriving it
+          # from pending nodes alone skipped the approval job on a
+          # kubernetesVersion-only bump, and upgrade-k8s is gated on that
+          # approval -- so the Kubernetes upgrade silently never ran.
+          if [[ "$nodes_pending" == "true" || "$upgrade_k8s" == "true" ]]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "upgrade-k8s=false" >> "$GITHUB_OUTPUT"
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
           fi
 
           {
@@ -190,7 +203,10 @@ jobs:
   control-plane:
     name: ${{ matrix.hostname }}
     needs: [plan, approve]
-    if: needs.approve.result == 'success' && needs.plan.outputs.control-plane-matrix != '[]'
+    if: >-
+      needs.approve.result == 'success'
+      && needs.plan.outputs.nodes-pending == 'true'
+      && needs.plan.outputs.control-plane-matrix != '[]'
     # Pinned to the Pi workers so a control plane job is never evicted by the
     # control plane node it is rebooting.
     runs-on: home-ops-runners-arm64
@@ -225,6 +241,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.approve.result == 'success'
+      && needs.plan.outputs.nodes-pending == 'true'
       && needs.plan.outputs.worker-matrix != '[]'
     # Pinned to the control plane, which by this point is already upgraded.
     runs-on: home-ops-runners-amd64
@@ -308,10 +325,15 @@ jobs:
       - name: Verify cluster
         env:
           TARGETS: ${{ needs.plan.outputs.target-hostnames }}
+          # Only meaningful when this run was actually responsible for the
+          # Kubernetes upgrade. A filtered run does not touch kubelets, so
+          # holding it to the target version would fail it for no reason.
+          CHECK_KUBELET: ${{ needs.plan.outputs.upgrade-k8s == 'true' && inputs.nodes == '' }}
         run: |
           set -euo pipefail
 
           target="$(yq eval -r '.talosVersion' talos/talenv.yaml)"
+          k8s_target="$(yq eval -r '.kubernetesVersion' talos/talenv.yaml)"
 
           # Only the nodes this run set out to upgrade decide pass or fail. A
           # dispatch limited with the `nodes` input deliberately leaves the rest
@@ -345,6 +367,10 @@ jobs:
             fi
             if [[ "$ready" != "True" ]]; then
               note="${note} :warning: not Ready"
+              stale=$(( stale + 1 ))
+            fi
+            if [[ "$CHECK_KUBELET" == "true" && "$kubelet" != "$k8s_target" ]]; then
+              note="${note} :warning: kubelet not on \`${k8s_target}\`"
               stale=$(( stale + 1 ))
             fi
             echo "| ${hostname} | ${version} | ${kubelet} | ${ready} | ${note} |" >> "$GITHUB_STEP_SUMMARY"

--- a/talos/UPGRADE.md
+++ b/talos/UPGRADE.md
@@ -63,8 +63,19 @@ rebooting healthy nodes.
 
 **Kubernetes.** If `kubernetesVersion` in `talenv.yaml` no longer matches the
 running kubelets, a final job runs `talosctl upgrade-k8s` after every node is
-done. A commit that only moves `kubernetesVersion` therefore upgrades
-Kubernetes without rebooting anything.
+done. That is a single cluster-wide command which rolls the control plane
+static pods and the kubelets in place — no reboots, no draining, and no
+per-node jobs.
+
+A commit that only moves `kubernetesVersion` therefore upgrades Kubernetes
+without rebooting anything: the node phases are skipped because every node
+already runs the target Talos version, and only the Kubernetes job runs. It
+still waits on the same approval.
+
+The Kubernetes job is deliberately skipped on a run limited with the `nodes`
+input — a partial rollout should not trigger a cluster-wide Kubernetes
+upgrade. Bump `kubernetesVersion` and let an unfiltered run handle it, or use
+`task talos:upgrade-k8s` by hand.
 
 The runners live in this cluster, so the workflow pins each phase to the nodes
 it is *not* touching: control plane jobs run on `home-ops-runners-arm64` (the


### PR DESCRIPTION
The Kubernetes upgrade job could never run for the case it exists to serve.

## The bug

```
approve:      if: needs.plan.outputs.should-run == 'true'
upgrade-k8s:  if: ... needs.approve.result == 'success' ...
```

`should-run` was derived from **pending nodes alone**. So a commit that moves only `kubernetesVersion`:

1. Triggers the workflow — `talos/talenv.yaml` changed
2. `plan` finds every node already on the target Talos version → `should-run=false`
3. `approve` is skipped
4. `upgrade-k8s` sees `approve.result == 'skipped'` → **skipped**
5. `verify` skipped for the same reason

The run goes green having done nothing. `UPGRADE.md` and the #543 description both claimed this path worked; they were wrong, and I wrote them.

This was about to start mattering. With every node on v1.13.8 after today's rollout, `should-run` is `false` for **every** future kubelet bump — starting with the open `ghcr.io/siderolabs/kubelet` PR (#495).

## The fix

- `should-run` now means *"there is work to do"* — nodes pending **or** a Kubernetes upgrade needed — so approval is reached either way.
- A new `nodes-pending` output gates the node phases. A `kubernetesVersion`-only bump therefore skips the eleven per-node jobs entirely, rather than spinning up eleven runners just to report "already on target" — which also removes eleven chances to hit the DNS flake that cost two dispatches today.
- `verify` gains a kubelet check, but **only when this run owned the Kubernetes upgrade** (`upgrade-k8s == 'true'` and unfiltered). A filtered node run never touches kubelets, so holding it to the target kubelet version would fail it for something it was never asked to change.

## Behaviour after this change

| scenario | node jobs | upgrade-k8s | verify |
|---|---|---|---|
| Talos bump only | run | skipped | Talos + Ready |
| **kubernetesVersion bump only** | **skipped** | **runs** | Talos + Ready + kubelet |
| both | run | runs | Talos + Ready + kubelet |
| filtered `nodes:` run | run | skipped (deliberate) | targeted nodes only |
| nothing pending | skipped | skipped | skipped |

The filtered-run exclusion is intentional and now documented: a partial rollout shouldn't trigger a cluster-wide Kubernetes upgrade.

## Note

Unverified end to end — the path can't be exercised until a `kubernetesVersion` bump exists to merge. #495 is the natural first test, and it upgrades kubelets v1.36.2 → v1.36.3 with no reboots.