### PR TITLE
fix(actions-runner-system): hold runners until DNS works in their pod

### DIFF
--- a/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
@@ -42,6 +42,27 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if getent hosts github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-07-29-e95765

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
@@ -53,6 +53,27 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if getent hosts github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
@@ -54,6 +54,27 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: arm64
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if getent hosts github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a

--- a/kubernetes/apps/actions-runner-system/khaoslabs-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/khaoslabs-runners/app/helmrelease.yaml
@@ -40,6 +40,27 @@ spec:
     # Runner template
     template:
       spec:
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if getent hosts github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-07-29-e95765


### PR DESCRIPTION
A runner pod that starts while its DNS path isn't usable yet is **poisoned for its entire life**.

glibc initialises resolver state once per process, so the .NET runner caches the failure and never re-reads `resolv.conf`. It then retries every 30 seconds forever, while the pod reports `Running`, the node is healthy, and the job sits `queued`.

## This bit three times today

| when | effect |
|---|---|
| 16:02 UTC | `Set up job` failed fetching `actions/checkout` — cp-3 dispatch died in `Plan` |
| 16:10 UTC | identical failure on the retry |
| 17:07 UTC | **stalled the `k8s-pi-3` upgrade for 14 minutes** until I deleted the pod by hand |

The decisive evidence, from the stuck pod:

```
# the runner process, still failing at 17:32:45
BrokerMessageListener ERR: Name or service not known (broker.actions.githubusercontent.com:443)

# getent, inside that same pod, seconds earlier
20.85.130.105   broker.actions.githubusercontent.com
140.82.113.4    github.com
10.43.0.1       kubernetes.default.svc.cluster.local
```

The pod's networking was fine. Only the process was broken — because it had started during a window when it wasn't.

## Fix

An init container in the same network namespace proves the runner's own DNS path before the runner starts:

```yaml
initContainers:
  - name: wait-for-dns
    image: busybox:1.36
    command: [sh, -c, 'for i in $(seq 1 60); do getent hosts github.com >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1']
```

If DNS never arrives within 2 minutes it fails the pod, so ARC replaces it — a fast, visible failure instead of a silent 14-minute spin.

Applied to **all four scale sets**. The failure mode isn't specific to `home-ops`, and `khaoslabs-runners` backs calypso-deploy's deployments. Trim that scope if you'd rather keep the blast radius to this repo.

## What this does not do

**It's a guard, not a cure.** The underlying blips are not root-caused.

Ruled out today: **Pi-hole rate limiting** — `dns.rateLimit` is at the default `count = 1000 / interval = 60`, and there are **zero** rate-limiting events in a log covering all three failure windows. CoreDNS also logged no errors, which is itself telling: the failing queries never reached it.

Best current theory is a race between container start and Cilium programming the pod endpoint — which fits every observation (only fresh pods affected, nothing logged upstream, later tests always pass) and is exactly what this guard closes. Unproven without catching it live.

Also filed for the separate log-noise problem found on the way: khaoslabs/calypso-deploy#129.