### PR TITLE
feat(actions-runner-system): runner pool for the observability cluster

### DIFF
--- a/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-ops-observability-runners
+  namespace: actions-runner-system
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-ops-observability-runners-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        github_app_id: "{{ .github_app_id }}"
+        github_app_installation_id: "{{ .github_app_installation_id }}"
+        github_app_private_key: "{{ .github_app_private_key }}"
+  dataFrom:
+    - extract:
+        key: home-ops-observability-github-runner

--- a/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/helmrelease.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: home-ops-observability-runners
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: home-ops-observability-runners
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: home-ops-observability-runners-secret
+      valuesKey: github_app_id
+      targetPath: githubConfigSecret.github_app_id
+    - kind: Secret
+      name: home-ops-observability-runners-secret
+      valuesKey: github_app_installation_id
+      targetPath: githubConfigSecret.github_app_installation_id
+    - kind: Secret
+      name: home-ops-observability-runners-secret
+      valuesKey: github_app_private_key
+      targetPath: githubConfigSecret.github_app_private_key
+  values:
+    # Repository-level runner pool for the observability cluster's repo.
+    githubConfigUrl: https://github.com/casmith/home-ops-observability
+    runnerScaleSetName: home-ops-observability-runners
+
+    # Scaling configuration. Scales from zero: the Talos upgrade workflow runs
+    # at most one node job at a time.
+    minRunners: 0
+    maxRunners: 2
+
+    # Deliberately unpinned. These runners upgrade a *different* cluster
+    # (obs-cp-1..3), so unlike home-ops-runners there is no node they must
+    # avoid -- a job here can never evict itself.
+
+    # Runner template
+    template:
+      spec:
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if getent hosts github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
+        containers:
+          - name: runner
+            image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a
+            command: ["/home/runner/run.sh"]
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 200m
+              limits:
+                memory: 1Gi
+                cpu: 1000m
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+
+        # Storage for runner work directory
+        volumes:
+          - name: work
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  storageClassName: local-path
+                  resources:
+                    requests:
+                      storage: 5Gi
+
+    # Controller settings
+    controllerServiceAccount:
+      namespace: actions-runner-system
+      name: actions-runner-controller

--- a/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: home-ops-observability-runners
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/home-ops-observability-runners/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-observability-runners/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-ops-observability-runners
+  namespace: &namespace actions-runner-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: actions-runner-controller
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/actions-runner-system/home-ops-observability-runners/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./khaoslabs-runners/ks.yaml
   - ./beoftexas-runners/ks.yaml
   - ./home-ops-runners/ks.yaml
+  - ./home-ops-observability-runners/ks.yaml


### PR DESCRIPTION
Part 1 of giving `casmith/home-ops-observability` the same Talos upgrade automation. This adds the runners; the workflow itself goes in that repo.

## Why it lives here

The observability cluster is three nodes, **all control plane** (`obs-cp-1/2/3`). There is nowhere inside it to put a runner that won't be rebooted — every node gets upgraded.

Hosting the pool in *this* cluster sidesteps that entirely: the runners upgrade a different cluster, so a job can never evict itself. That means **no arch-pinned pools**, which was the trickiest part of #542 and the source of the split `-amd64` / `-arm64` design here.

## Notable

- **Unpinned** — no `nodeSelector`. Any node in home-ops is safe for these runners.
- **Scales from zero**, `maxRunners: 2` — the upgrade workflow runs one node at a time.
- **Ships with the DNS startup guard** from #551 rather than learning it twice. A runner that starts before its pod's DNS path is programmed caches the failure in glibc and retries forever while the job sits `queued` — that cost three failures today.

## Requires

- The GitHub App installed on `casmith/home-ops-observability`
- A 1Password item **`home-ops-observability-github-runner`** with `github_app_id`, `github_app_installation_id`, `github_app_private_key` — matching the naming of the existing three

## After merging

```bash
kubectl -n actions-runner-system get externalsecret home-ops-observability-runners
kubectl -n actions-runner-system get pods | grep observability
```

Expect `SecretSynced` and one `-listener` pod. If the listener never appears, check the ARC controller logs for a 403 on `registration-token` — that's the App missing **Administration: Read and write**, exactly as happened with #542.