### PR TITLE
Revert "fix(actions-runner-system): hold runners until DNS works in their pod"

### DIFF
--- a/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
@@ -42,27 +42,6 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
-        initContainers:
-          # glibc initialises resolver state once per process. A runner that
-          # starts while the pod's DNS path is not yet programmed caches that
-          # failure and retries forever without ever re-reading resolv.conf --
-          # the pod looks healthy, the job sits queued, and nothing recovers.
-          # Hold the runner until resolution demonstrably works from this pod.
-          - name: wait-for-dns
-            image: busybox:1.36
-            command:
-              - sh
-              - -c
-              - |
-                for i in $(seq 1 60); do
-                  if getent hosts github.com >/dev/null 2>&1; then
-                    echo "dns ready after $(( (i - 1) * 2 ))s"
-                    exit 0
-                  fi
-                  sleep 2
-                done
-                echo "dns never became usable; failing so the pod is replaced"
-                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-07-29-e95765

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
@@ -53,27 +53,6 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
-        initContainers:
-          # glibc initialises resolver state once per process. A runner that
-          # starts while the pod's DNS path is not yet programmed caches that
-          # failure and retries forever without ever re-reading resolv.conf --
-          # the pod looks healthy, the job sits queued, and nothing recovers.
-          # Hold the runner until resolution demonstrably works from this pod.
-          - name: wait-for-dns
-            image: busybox:1.36
-            command:
-              - sh
-              - -c
-              - |
-                for i in $(seq 1 60); do
-                  if getent hosts github.com >/dev/null 2>&1; then
-                    echo "dns ready after $(( (i - 1) * 2 ))s"
-                    exit 0
-                  fi
-                  sleep 2
-                done
-                echo "dns never became usable; failing so the pod is replaced"
-                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
@@ -54,27 +54,6 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: arm64
-        initContainers:
-          # glibc initialises resolver state once per process. A runner that
-          # starts while the pod's DNS path is not yet programmed caches that
-          # failure and retries forever without ever re-reading resolv.conf --
-          # the pod looks healthy, the job sits queued, and nothing recovers.
-          # Hold the runner until resolution demonstrably works from this pod.
-          - name: wait-for-dns
-            image: busybox:1.36
-            command:
-              - sh
-              - -c
-              - |
-                for i in $(seq 1 60); do
-                  if getent hosts github.com >/dev/null 2>&1; then
-                    echo "dns ready after $(( (i - 1) * 2 ))s"
-                    exit 0
-                  fi
-                  sleep 2
-                done
-                echo "dns never became usable; failing so the pod is replaced"
-                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a

--- a/kubernetes/apps/actions-runner-system/khaoslabs-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/khaoslabs-runners/app/helmrelease.yaml
@@ -40,27 +40,6 @@ spec:
     # Runner template
     template:
       spec:
-        initContainers:
-          # glibc initialises resolver state once per process. A runner that
-          # starts while the pod's DNS path is not yet programmed caches that
-          # failure and retries forever without ever re-reading resolv.conf --
-          # the pod looks healthy, the job sits queued, and nothing recovers.
-          # Hold the runner until resolution demonstrably works from this pod.
-          - name: wait-for-dns
-            image: busybox:1.36
-            command:
-              - sh
-              - -c
-              - |
-                for i in $(seq 1 60); do
-                  if getent hosts github.com >/dev/null 2>&1; then
-                    echo "dns ready after $(( (i - 1) * 2 ))s"
-                    exit 0
-                  fi
-                  sleep 2
-                done
-                echo "dns never became usable; failing so the pod is replaced"
-                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-07-29-e95765


### PR DESCRIPTION
**Reverting #551 — it broke every runner in the cluster.**

`busybox:1.36` does not ship `getent`:

```
$ kubectl run --image=busybox:1.36 -- sh -c 'command -v getent; getent hosts github.com; nslookup github.com'
getent: MISSING
sh: getent: not found
nslookup: works
```

So the guard's condition can never succeed. Every runner pod waits the full 120s, exits 1, is replaced by ARC, and loops — no job can start on any pool. All four scale sets were affected, including `khaoslabs-runners`, which backs calypso-deploy.

## How I missed it

I validated the guard's *placement* — YAML parse, kustomize build, helm render, correct nesting under `template.spec` rather than `listenerTemplate.spec` — but never validated that the *command runs in that image*. I had tested `getent` inside the runner pod, which is Ubuntu-based and has it, and assumed busybox did too.

Restoring CI first; the corrected guard follows in a separate PR using `nslookup`, which busybox does provide, verified in the image before merging this time.