### PR TITLE
fix(actions-runner-system): re-land the DNS startup guard, using nslookup

### DIFF
--- a/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
@@ -42,6 +42,32 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          #
+          # nslookup, not getent: busybox ships no getent, so the first attempt
+          # at this guard could never succeed and failed every runner in the
+          # cluster. Verified in busybox:1.36 -- exit 0 when resolution works,
+          # exit 1 against a blackhole resolver.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if nslookup github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-07-29-e95765

--- a/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/helmrelease.yaml
@@ -52,6 +52,11 @@ spec:
           # failure and retries forever without ever re-reading resolv.conf --
           # the pod looks healthy, the job sits queued, and nothing recovers.
           # Hold the runner until resolution demonstrably works from this pod.
+          #
+          # nslookup, not getent: busybox ships no getent, so the first attempt
+          # at this guard could never succeed and failed every runner in the
+          # cluster. Verified in busybox:1.36 -- exit 0 when resolution works,
+          # exit 1 against a blackhole resolver.
           - name: wait-for-dns
             image: busybox:1.36
             command:
@@ -59,7 +64,7 @@ spec:
               - -c
               - |
                 for i in $(seq 1 60); do
-                  if getent hosts github.com >/dev/null 2>&1; then
+                  if nslookup github.com >/dev/null 2>&1; then
                     echo "dns ready after $(( (i - 1) * 2 ))s"
                     exit 0
                   fi

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-amd64.yaml
@@ -53,6 +53,32 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          #
+          # nslookup, not getent: busybox ships no getent, so the first attempt
+          # at this guard could never succeed and failed every runner in the
+          # cluster. Verified in busybox:1.36 -- exit 0 when resolution works,
+          # exit 1 against a blackhole resolver.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if nslookup github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a

--- a/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runners/app/helmrelease-arm64.yaml
@@ -54,6 +54,32 @@ spec:
       spec:
         nodeSelector:
           kubernetes.io/arch: arm64
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          #
+          # nslookup, not getent: busybox ships no getent, so the first attempt
+          # at this guard could never succeed and failed every runner in the
+          # cluster. Verified in busybox:1.36 -- exit 0 when resolution works,
+          # exit 1 against a blackhole resolver.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if nslookup github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-06-08-a6d13a

--- a/kubernetes/apps/actions-runner-system/khaoslabs-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/khaoslabs-runners/app/helmrelease.yaml
@@ -40,6 +40,32 @@ spec:
     # Runner template
     template:
       spec:
+        initContainers:
+          # glibc initialises resolver state once per process. A runner that
+          # starts while the pod's DNS path is not yet programmed caches that
+          # failure and retries forever without ever re-reading resolv.conf --
+          # the pod looks healthy, the job sits queued, and nothing recovers.
+          # Hold the runner until resolution demonstrably works from this pod.
+          #
+          # nslookup, not getent: busybox ships no getent, so the first attempt
+          # at this guard could never succeed and failed every runner in the
+          # cluster. Verified in busybox:1.36 -- exit 0 when resolution works,
+          # exit 1 against a blackhole resolver.
+          - name: wait-for-dns
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - |
+                for i in $(seq 1 60); do
+                  if nslookup github.com >/dev/null 2>&1; then
+                    echo "dns ready after $(( (i - 1) * 2 ))s"
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                echo "dns never became usable; failing so the pod is replaced"
+                exit 1
         containers:
           - name: runner
             image: ghcr.io/khaoslabs/actions-runner:2026-07-29-e95765


### PR DESCRIPTION
Re-lands #551 with the bug fixed. That PR ran `getent hosts github.com` in `busybox:1.36`, which ships **no getent** — so the condition never succeeded, every runner burned 120s and failed, and no job could start on any pool. Reverted in #553.

## Verified this time, not assumed

Ran the actual init script in the actual image:

| case | result |
|---|---|
| working DNS | `phase=Succeeded`, `exitCode=0`, `dns ready after 0s` |
| blackhole resolver (`192.0.2.1`) | exits 1 after retries |

`nslookup` is present in busybox and discriminates correctly in both directions — which matters, because a check that returns success on failure would be worse than no check.

## Scope

All five pools, including **`home-ops-observability-runners`**, which #552 added with the same broken command baked in and which #553 did not touch — so that one is still carrying the `getent` version on `main` right now. It isn't running yet (its ExternalSecret is unresolved pending the 1Password item), but it would have failed the same way.

## Unchanged intent

glibc initialises resolver state once per process. A runner that starts before its pod's DNS path is usable caches that failure and retries forever while the pod reports healthy and the job sits `queued` — that cost two failed dispatches and a 14-minute stall today. The init container shares the pod's network namespace, so it proves the exact path the runner will use, and fails fast if DNS never arrives.

Still a guard, not a cure: the underlying blips remain un-root-caused. Pi-hole rate limiting is ruled out with evidence; best remaining theory is a container-start / Cilium endpoint-programming race.