### PR TITLE
fix(actions-runner-system): share the home-ops App for observability runners

### DIFF
--- a/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-observability-runners/app/externalsecret.yaml
@@ -18,6 +18,12 @@ spec:
         github_app_id: "{{ .github_app_id }}"
         github_app_installation_id: "{{ .github_app_installation_id }}"
         github_app_private_key: "{{ .github_app_private_key }}"
+  # Shares the home-ops GitHub App rather than having its own. A GitHub App can
+  # be installed across several repositories, and the installation ID is per
+  # account, so granting that App access to casmith/home-ops-observability
+  # leaves all three credential values identical -- no second App, no second
+  # item to rotate. The other pools each have their own App; this one
+  # deliberately does not.
   dataFrom:
     - extract:
-        key: home-ops-observability-github-runner
+        key: home-ops-github-runner


### PR DESCRIPTION
Removes the need for a second GitHub App and a second 1Password item.

A GitHub App can be installed across multiple repositories, and the **installation ID is per account, not per repo**. So granting the existing home-ops App access to `casmith/home-ops-observability` leaves `app_id`, `installation_id` and the private key all unchanged — the observability pool can read the same credentials.

This repoints its ExternalSecret at the existing **`home-ops-github-runner`** item and drops `home-ops-observability-github-runner`, which #552's description asked you to create unnecessarily.

## What you still need to do

**One manual step, in GitHub App settings:** add `casmith/home-ops-observability` to the App's repository access. Nothing else — no new App, no new item, no new secret to rotate.

Then the ExternalSecret resolves and the pool's listener comes up. The `key not found in 1Password Vaults` events currently firing every few seconds will stop once this merges, since the item it was looking for was never going to exist.

## Divergence, noted deliberately

The other three pools each have their own App. This one shares. The trade-off is one credential covering two repos — both in the same account — against one fewer `Administration: Read and write` App to create, install and rotate. Easy to split later if you'd rather: create the App, and change this one line back.