### PR TITLE
docs(postmortems): record the mealie multi-attach and iSCSI node-db incidents

### DIFF
--- a/docs/postmortems/2026-07-14-mealie-multi-attach.md
+++ b/docs/postmortems/2026-07-14-mealie-multi-attach.md
@@ -1,0 +1,218 @@
+# Postmortem: Mealie stuck in Multi-Attach, 2026-07-14
+
+## Summary
+
+Mealie would not start. Every new pod failed to schedule with:
+
+```
+Multi-Attach error for volume "pvc-4cb39f25-4dda-44d5-814e-5f6058d3fa1f"
+Volume is already exclusively attached to one node and can't be attached to another
+```
+
+Longhorn reported the volume as `attached` to `k8s-pi-7` even though the mealie
+Deployment had been scaled to zero and no pod referencing the PVC existed
+anywhere in the cluster.
+
+The cause was **not** Longhorn. Kubelet on `k8s-pi-7` was wedged in a permanent
+unmount-retry loop for a pod that no longer existed, which kept the volume pinned
+to that node. Longhorn was correctly refusing to detach a volume that a kubelet
+still claimed was in use.
+
+Resolution: restart kubelet on `k8s-pi-7`, then clean up a dead mount the restart
+left behind. Total data loss: none. The 49M of recipe images/assets on the PVC
+came back intact.
+
+## Impact
+
+- Mealie was unavailable until the wedged kubelet was restarted.
+- No other workload was affected. The volume's data was never at risk.
+- `k8s-pi-7` had been spending a couple of CPU-seconds a minute failing the same
+  unmount, silently, for an unknown length of time.
+
+## Root cause
+
+The failure is a chain, and every link has to be understood to see why scaling to
+zero could not possibly have fixed it.
+
+1. An earlier mealie pod (UID `ccb49f5e-f304-43ec-915f-3bd381de99e2`) died messily
+   on `k8s-pi-7`. Its teardown left an orphaned directory at
+   `/var/lib/kubelet/pods/ccb49f5e-.../` whose
+   `volumes/kubernetes.io~csi/pvc-4cb39f25-.../vol_data.json` was **missing**.
+
+2. Kubelet needs `vol_data.json` to construct a CSI unmounter. Without it,
+   `UnmountVolume` fails immediately and permanently:
+
+   ```
+   UnmountVolume.NewUnmounter failed for volume
+     "kubernetes.io/csi/driver.longhorn.io^pvc-4cb39f25-..."
+     pod "ccb49f5e-f304-43ec-915f-3bd381de99e2":
+   kubernetes.io/csi: failed to open volume data file
+     [.../pvc-4cb39f25-.../vol_data.json]: no such file or directory
+   ```
+
+   Kubelet retried this roughly every two seconds, indefinitely.
+
+3. Because the unmount never succeeded, the volume never left kubelet's
+   actual-state-of-world, so the node kept advertising it in
+   `node.status.volumesInUse`.
+
+4. **The attach/detach controller will not detach a volume that a node reports as
+   in-use.** So it never even issued a detach request — the `VolumeAttachment`
+   `csi-e3be7475...` had `attached: true` and *no* `deletionTimestamp`. Nobody had
+   ever asked for it to go away.
+
+5. Longhorn, doing exactly as it was told, held the attachment to `k8s-pi-7`.
+
+6. The replacement mealie pod scheduled onto `k8s-cp-2`, tried to attach a volume
+   still exclusively held by `k8s-pi-7`, and got the Multi-Attach error.
+
+Scaling the Deployment to zero had no effect because **the thing pinning the
+volume was a ghost pod that no longer existed in the Kubernetes API.** There was
+nothing left to scale down. The only trace of it was a directory on one node's
+disk and an entry in one kubelet's memory.
+
+### What caused the messy teardown
+
+Not conclusively established. The Longhorn CSI plugin logs on `k8s-pi-7` show the
+control plane was unhealthy immediately before the bad teardown — `longhorn-backend`
+was timing out:
+
+```
+NodeGetVolumeStats: ... err: ... failed to get volume pvc-4cb39f25-... for volume statistics:
+Get "http://longhorn-backend:9500/v1/volumes/pvc-4cb39f25-...": context deadline exceeded
+```
+
+A pod teardown racing a struggling Longhorn control plane is a plausible way to
+lose `vol_data.json` partway through cleanup, but this is inference, not proof.
+
+Note the pod that scaled down *cleanly* (`ae5de1a3-...`) logged a successful
+`NodeUnpublishVolume` and never appeared in the failure loop. Only the ghost pod
+`ccb49f5e-...` was stuck. This is what confirmed the problem was one specific
+orphaned directory rather than anything systemic.
+
+## Resolution
+
+### 1. Restart kubelet on the wedged node
+
+```sh
+talosctl -e 192.168.10.77 -n 192.168.10.77 service kubelet restart
+```
+
+On startup kubelet rebuilds its volume state from disk. Since the volume directory
+was already gone, it simply did not recreate the phantom mount, stopped retrying,
+and dropped the volume from `volumesInUse`. The attach/detach controller then
+detached it normally. This cleared in under 10 seconds. Kubelet also
+garbage-collected the orphaned pod directory on its own.
+
+A kubelet restart does **not** kill running containers, so the other workloads on
+`k8s-pi-7` were undisturbed.
+
+### 2. Clean up the dead globalmount
+
+The detach happened without kubelet ever calling `NodeUnstageVolume`, which
+stranded the CSI staging mount. The kernel had shut the filesystem down when its
+backing device vanished:
+
+```
+/dev/longhorn/pvc-4cb39f25-... /var/lib/kubelet/plugins/.../globalmount ext4 rw,...,emergency_ro,shutdown
+```
+
+`emergency_ro,shutdown` — reads returned `Input/output error`, and
+`/dev/longhorn/pvc-4cb39f25-...` no longer existed. This mattered because the
+globalmount path is a deterministic hash of the volume ID: if mealie ever
+rescheduled onto `k8s-pi-7`, `NodeStageVolume` would target that exact same path.
+
+Unmounted it through the `longhorn-csi-plugin` pod, which mounts `/var/lib/kubelet`
+with bidirectional propagation, so the unmount reaches the host — no reboot and no
+extra privileged pod required:
+
+```sh
+GM=/var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/<hash>/globalmount
+kubectl exec -n longhorn-system <longhorn-csi-plugin-pod> -c longhorn-csi-plugin -- umount $GM
+```
+
+Unmounting was safe: the filesystem was already shut down and read-only, and its
+backing device was gone, so there was nothing to flush.
+
+### 3. Scale mealie back up
+
+```sh
+kubectl scale deploy mealie -n default --replicas=1
+```
+
+Pod came up Ready on `k8s-cp-2`, volume `attached / healthy`, data intact.
+
+## How to recognise this again
+
+The diagnostic signature is specific, and worth committing to memory because it
+looks like a Longhorn bug and is not one:
+
+- A `VolumeAttachment` that is `attached: true` with **no `deletionTimestamp`**.
+  This is the key tell. It means nothing ever *asked* for a detach — so the
+  storage layer is not stuck, the request was never made.
+- The volume still listed in some node's `.status.volumesInUse`.
+- No pod anywhere in the API referencing the PVC.
+
+That combination always means **a wedged kubelet, not a Longhorn problem.**
+Restart kubelet on the node named in `volumesInUse`.
+
+```sh
+PV=pvc-xxxxxxxx   # the PV from the Multi-Attach error
+
+# Is a detach even being requested? (empty deletionTimestamp => no)
+kubectl get volumeattachment -o json \
+  | jq -r --arg pv "$PV" '.items[]
+      | select(.spec.source.persistentVolumeName==$pv)
+      | {name:.metadata.name, node:.spec.nodeName, attached:.status.attached,
+         deletionTimestamp:.metadata.deletionTimestamp}'
+
+# Which node still claims it is in use?
+kubectl get nodes -o json \
+  | jq -r --arg pv "$PV" '.items[]
+      | select(.status.volumesInUse[]? | test($pv)) | .metadata.name'
+
+# Confirm no pod actually references the PVC
+kubectl get pods -A -o json \
+  | jq -r '.items[] | select(.spec.volumes[]?.persistentVolumeClaim.claimName // "" | test("<pvc-name>"))
+      | "\(.metadata.namespace)/\(.metadata.name)"'
+
+# Confirm the kubelet retry loop on the offending node
+talosctl -e <node-ip> -n <node-ip> logs kubelet | grep "$PV" | grep -i "UnmountVolume failed"
+```
+
+After the kubelet restart, check for a stranded globalmount before declaring
+victory — `NodeUnstageVolume` may never have run:
+
+```sh
+talosctl -e <node-ip> -n <node-ip> mounts | grep "$PV"
+```
+
+If it is still listed with `emergency_ro,shutdown` in `/proc/mounts`, unmount it as
+in step 2 above.
+
+## Gotchas hit while debugging
+
+Recording these because both cost real time and both produce *convincingly wrong*
+answers rather than errors.
+
+- **`talosctl -n k8s-pi-7` does not work.** Talos node names here do not resolve;
+  you must pass the IP (`-e 192.168.10.77 -n 192.168.10.77`). The failure mode is
+  nasty: some subcommands return an empty result rather than an error, so
+  `talosctl -n k8s-pi-7 mounts | grep <pv>` printed nothing and I briefly concluded
+  the volume was not mounted on the node. It was. Always pass the IP, and sanity-check
+  that the command returns *something* before trusting a negative result.
+
+- **`talosctl mounts` reports plausible size/usage figures for a dead mount.** The
+  stranded globalmount showed `5.20 GB / 1.30% used` as though healthy, because the
+  kernel still had the superblock cached. Only `ls` (which returned `EIO`) and the
+  `emergency_ro,shutdown` flags in `/proc/mounts` revealed it was dead. Do not treat
+  a normal-looking `mounts` line as evidence a mount is healthy.
+
+## Follow-ups
+
+- [ ] Nothing in the repo needed changing — this was purely cluster runtime state,
+      so there is no commit associated with the fix.
+- [ ] The trigger (Longhorn control-plane timeouts during pod teardown) was not
+      root-caused. If Multi-Attach recurs on any app, check whether
+      `longhorn-backend` is timing out under load rather than treating each
+      occurrence as a one-off.

--- a/docs/postmortems/2026-08-06-longhorn-iscsi-node-db-poison.md
+++ b/docs/postmortems/2026-08-06-longhorn-iscsi-node-db-poison.md
@@ -1,0 +1,228 @@
+# Postmortem: Longhorn volumes unattachable on pi-6 and pi-5, 2026-08-06
+
+## Summary
+
+Mealie and MouseSearch would not start on `k8s-pi-6`. Both pods sat in
+`ContainerCreating` / `Init:0/1` with:
+
+```
+AttachVolume.Attach failed for volume "pvc-4cb39f25-4dda-44d5-814e-5f6058d3fa1f":
+rpc error: code = DeadlineExceeded desc = volume ... failed to attach to node k8s-pi-6
+```
+
+Longhorn showed the volumes stuck in `attaching`, robustness `unknown`.
+
+The cause was **not** Longhorn, and not the volumes named in the errors. Four
+nodes had accumulated stale iSCSI node records under `/var/lib/iscsi/nodes/`
+containing `node.session.conn_reopen_log_freq`, a parameter the running
+`libopeniscsiusr` does not recognise. Because `iscsiadm -m node ... -o show`
+parses the **entire** node database, a single unreadable record made every iSCSI
+operation on that node fail — so no volume could attach there, regardless of
+which volume it was.
+
+Resolution: delete the 28 stale record directories across the four affected
+nodes. Longhorn rewrites them cleanly on the next attach. Total data loss: none.
+
+## Impact
+
+- **Mealie** and **MouseSearch** were unavailable on `k8s-pi-6`.
+- **beets** (`pvc-6efd14ad`) hit the same wall and its volume went
+  `detaching` → `faulted` → `detached`. No user impact: `beets-shell` is declared
+  `replicas: 0` in Git (`kubernetes/apps/default/beets/app/helmrelease.yaml:75`),
+  an on-demand shell, so nothing was trying to run.
+- **`k8s-pi-5` was failing identically** and had been for some time — 144 of the
+  same error in its `longhorn-manager` log. It just had no pod actively demanding
+  an attach, so nobody noticed.
+- **`k8s-cp-1` (6 records) and `k8s-cp-2` (14 records) were latent.** Not erroring
+  only because nothing had recently tried to attach there. Any volume scheduled
+  onto them would have hit the same wall.
+- **Silent replica-scheduling damage.** Mealie, MouseSearch and beets all specify
+  `numberOfReplicas: 3` but were running on **one** replica each, all on `k8s-cp-3`.
+  Longhorn had been unable to build replicas on pi-5 or pi-6 for months. This was
+  the more dangerous half of the incident: three volumes sitting at a single
+  replica with no alert, presenting as `healthy` whenever they happened to be
+  attached.
+
+## Root cause
+
+1. `iscsiadm` wrote node records containing `node.session.conn_reopen_log_freq`.
+   The affected records on `k8s-pi-6` are dated **Feb 15 18:33** and **Apr 2 12:03**.
+
+2. The `libopeniscsiusr` in use today does not know that parameter. Reading any
+   such record fails hard:
+
+   ```
+   iSCSI ERROR: Unknown parameter name node.session.conn_reopen_log_freq
+     # ../libopeniscsiusr/idbm.c:_idbm_rec_update_param():780
+   iSCSI ERROR: config file /var/lib/iscsi/nodes/iqn.2019-10.io.longhorn:pvc-0a8806ae-.../10.42.8.158,3260,1/default invalid.
+     # ../libopeniscsiusr/idbm.c:_idbm_recs_read():919: exit status 7
+   ```
+
+3. **This is the crux: `iscsiadm -m node -o show` reads the whole node database,
+   not just the record you asked about.** One bad record poisons every query.
+
+4. Longhorn's engine starts fine, connects to its replica, and then dies at
+   frontend startup when it queries `node.session.scan`:
+
+   ```
+   Failed to startup frontend: Failed to get node.session.scan mode: failed to execute:
+     iscsiadm -m node -T iqn.2019-10.io.longhorn:pvc-4cb39f25-... -p 10.42.8.150 -o show
+   ```
+
+   Note the mismatch — it queries the **mealie** volume and fails on a record
+   belonging to an **unrelated** volume. That mismatch is the diagnostic signature.
+
+5. Engine crashes → volume stays `attaching` → CSI attach times out with
+   `DeadlineExceeded` → pod never starts. Longhorn then retries forever, which is
+   why `k8s-pi-6` logged 612 instances of the error in a five-minute window.
+
+All 28 poisoned records were **stale**. Every one referenced a dead
+instance-manager pod IP (on pi-6: `10.42.8.158` and `10.42.8.62`, against a
+current `10.42.8.150`), and none belonged to a volume attached on the node
+holding it. Twelve of them — `pvc-4d423b1f`, `pvc-a4737159`, `pvc-c6c6a194` on
+`k8s-cp-2` — referenced volumes Longhorn no longer has at all. These were
+leftovers from RWX share-manager pods that had since moved to other nodes.
+
+### What wrote the bad parameter
+
+**Not conclusively established.** What is known:
+
+- Records written on the day of the incident (Aug 6 01:32) do **not** contain the
+  parameter. Only the Feb/Apr ones do.
+- `/etc/iscsi/iscsid.conf` on `k8s-pi-6` does not set it, so it came from
+  `iscsiadm`'s built-in defaults at record-creation time.
+- The `iscsi-tools` Talos extension reads **v0.2.0 on all 11 nodes** right now, so
+  the current state shows no version skew to blame.
+
+The most likely explanation is a change in the iSCSI tooling between April and
+now — either an extension rebuild or a Longhorn upgrade altering how records are
+created. A second possibility, which the current-state evidence cannot rule out,
+is the known open-iscsi split where `iscsiadm`'s own `idbm` parameter table and
+`libopeniscsiusr`'s separate copy disagree, letting the same version write records
+it cannot read back. Distinguishing these would need the extension's build history,
+which the running cluster does not carry.
+
+This is inference, not proof. It does not affect the fix.
+
+## Resolution
+
+Nothing in the repo changed — this was purely host runtime state, so there is no
+commit associated with the fix.
+
+### 1. Find the poisoned records
+
+```sh
+for ip in <all node IPs>; do
+  echo -n "$ip: "
+  for f in $(talosctl -n $ip ls -r /var/lib/iscsi/nodes 2>/dev/null | awk '$2 ~ /default$/ {print $2}'); do
+    talosctl -n $ip read "/var/lib/iscsi/nodes/$f" 2>/dev/null | grep -q conn_reopen_log_freq && echo "  BAD $f"
+  done
+done
+```
+
+Result: `k8s-cp-1` 6, `k8s-cp-2` 14, `k8s-pi-5` 3, `k8s-pi-6` 5. Twenty-eight total.
+
+### 2. Delete them through an instance-manager pod
+
+`talosctl` has no `rm`. The `instance-manager` pods mount **host `/` at `/host`**,
+which is the shortest path to the files without creating a privileged debug pod:
+
+```sh
+kubectl exec -n longhorn-system <instance-manager-on-node> -- \
+  rm -rf '/host/var/lib/iscsi/nodes/iqn.2019-10.io.longhorn:pvc-0a8806ae-.../10.42.8.158,3260,1'
+```
+
+Before deleting, each record was checked against the live attachment map and
+skipped if its volume was attached on that same node. All 28 passed. Contents were
+backed up first — they are regenerable, but the copy costs nothing.
+
+Empty parent IQN directories were pruned afterwards with
+`find /host/var/lib/iscsi/nodes -mindepth 1 -maxdepth 1 -type d -empty -exec rmdir {} \;`.
+
+### 3. Verify
+
+```sh
+# rescan all nodes -> expect 0 bad everywhere
+# then confirm the error has actually stopped, not just gone quiet:
+kubectl logs -n longhorn-system <longhorn-manager-pod> -c longhorn-manager --since=60s \
+  | grep -c conn_reopen_log_freq
+```
+
+Last error on `k8s-pi-6` was `06:43:41Z`; zero in the following 60 seconds. Mealie
+and MouseSearch reached `1/1 Running` within about two minutes, no intervention
+needed — the existing pods recovered on their own retry.
+
+### 4. Replicas rebuilt themselves
+
+Once iSCSI worked again, Longhorn immediately built the missing replicas on
+exactly the two nodes that had been broken:
+
+```
+k8s-cp-3  24 replicas
+k8s-pi-6  22 replicas
+k8s-pi-5  22 replicas
+```
+
+Mealie and MouseSearch returned to `healthy` robustness at the full 3 replicas.
+This is strong confirmation that the single-replica state was a symptom of this
+bug rather than a separate misconfiguration — no replica settings were touched.
+
+## How to recognise this again
+
+The signature is specific and looks like a Longhorn bug when it is not:
+
+- **`iscsiadm` fails on a config file for a volume other than the one it queried.**
+  This is the tell. If the error names a different PVC than the command, you are
+  looking at node-database poisoning, not a problem with the volume being attached.
+- Volume stuck in `attaching`, engine cycling `starting` → `error` → `stopped`.
+- CSI reports `DeadlineExceeded`, not a permission or scheduling failure.
+- **Every** volume on that node fails, not just one — but you may only see one if
+  only one is being scheduled there.
+
+If it recurs, the same scan in step 1 finds it. Worth running on all nodes rather
+than just the one that is visibly broken: three of the four affected nodes here
+were not throwing errors at the time.
+
+## Gotchas hit while debugging
+
+- **`nsenter` into the iscsid mount namespace gives you `iscsiadm` and almost
+  nothing else.** The Talos extension rootfs has no `ls`, no `sh`. Both
+  `nsenter --mount=/host/proc/<pid>/ns/mnt ls ...` and `... /bin/sh -c ...` fail
+  with `No such file or directory` — which reads like a missing path rather than a
+  missing binary, and briefly looks like the node database is not there. It is.
+  Go through the `instance-manager` pod's `/host` mount instead.
+
+- **`longhorn-manager` does not mount `/var/lib/iscsi`.** It mounts `/host/boot`,
+  `/host/dev`, `/host/proc`, `/host/etc` and `/var/lib/longhorn` — enough to
+  `nsenter`, not enough to edit the node database. `longhorn-csi-plugin` does not
+  mount it either. `instance-manager` is the one that mounts host `/`.
+
+- **Latent damage does not show up in logs.** `k8s-cp-1` and `k8s-cp-2` had 20 of
+  the 28 bad records between them and zero errors in their manager logs, purely
+  because no attach had been attempted. Grepping logs to find affected nodes would
+  have found two of four. Scan the filesystem.
+
+- **A `healthy` volume can still be a single replica.** Longhorn reports
+  robustness relative to what it has managed to schedule; `degraded` only appeared
+  once the volume was attached and actively short. The real check is
+  `.spec.numberOfReplicas` against the actual replica count.
+
+- **`talosctl -n <ip>` works fine here** — contrast the 2026-07-14 postmortem's
+  note about node names not resolving. IPs were used throughout.
+
+## Follow-ups
+
+- [ ] The trigger was not root-caused (see *What wrote the bad parameter*). If this
+      recurs, capture the `iscsi-tools` extension version and Longhorn version at
+      the time the bad records appear — the current-state evidence is not enough to
+      distinguish a tooling change from the open-iscsi `idbm`/`libopeniscsiusr`
+      table split.
+- [ ] Consider a periodic scan for poisoned records. This failure is silent until
+      a pod happens to schedule onto an affected node, and it degraded replica
+      counts for months without surfacing.
+- [ ] Longhorn does not garbage-collect node records for volumes that have moved
+      away or been deleted. Twelve of the 28 records here referenced volumes that
+      no longer exist. Worth periodic pruning independent of this bug.
+- [ ] `k8s-pi-1` through `k8s-pi-4` remain `allowScheduling: false` in Longhorn
+      (pre-existing drift, unrelated to this incident but it narrows where replicas
+      can land, which made the single-replica state worse than it needed to be).


### PR DESCRIPTION
Adds `docs/postmortems/` with writeups for two storage incidents. Documentation only — no manifest or cluster changes. Both fixes were host runtime state, so neither has an associated commit.

### `2026-07-14-mealie-multi-attach.md`

Mealie stuck in `Multi-Attach`. A wedged kubelet on `k8s-pi-7` kept the volume pinned via a ghost pod that no longer existed in the API, so scaling to zero could not have helped. Looked like a Longhorn fault and was not one.

Key tell recorded: a `VolumeAttachment` that is `attached: true` with **no `deletionTimestamp`** — nothing ever asked for a detach, so the storage layer was never stuck.

This file was written at the time but never committed.

### `2026-08-06-longhorn-iscsi-node-db-poison.md`

Mealie and MouseSearch failed to mount on `k8s-pi-6` with `AttachVolume.Attach ... DeadlineExceeded`.

Stale records under `/var/lib/iscsi/nodes/` contained `node.session.conn_reopen_log_freq`, which the running `libopeniscsiusr` does not recognise. Since `iscsiadm -m node -o show` parses the **entire** node database, one unreadable record broke every volume attach on the node. Fixed by deleting 28 stale record directories across cp-1, cp-2, pi-5 and pi-6.

Two things worth pulling out of the writeup:

- **The outage was the smaller half.** Mealie, MouseSearch and beets all specify `numberOfReplicas: 3` but had been running on a **single replica** on `k8s-cp-3` for months — Longhorn could not build replicas on pi-5 or pi-6 while iSCSI was broken there. Nothing surfaced this. All three returned to 3 replicas on their own once the records were gone.
- **Three of the four affected nodes were not throwing errors**, because nothing had recently tried to attach there. Grepping logs to find the blast radius would have found one node out of four. The detection recipe in the doc scans the filesystem instead.

The trigger is documented as **not conclusively root-caused** — the `iscsi-tools` extension reads v0.2.0 on all 11 nodes now, so current state shows no skew to blame. Two candidate explanations are recorded along with what evidence would settle it.

### Follow-ups (unchecked in the doc, not addressed here)

- Periodic scan for poisoned records — this failure is silent until a pod happens to land on an affected node.
- Longhorn does not GC node records for departed or deleted volumes; 12 of the 28 referenced volumes that no longer exist.
- `k8s-pi-1`..`pi-4` remain `allowScheduling: false` in Longhorn (pre-existing drift, unrelated, but it narrowed where replicas could land).