### PR TITLE
fix(beets): resume import cronjob now that storage is recovered

### DIFF
--- a/kubernetes/apps/default/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/default/beets/app/helmrelease.yaml
@@ -25,7 +25,6 @@ spec:
       beets:
         type: cronjob
         cronjob:
-          suspend: true
           concurrencyPolicy: Forbid
           startingDeadlineSeconds: 60
           # A large import can outrun the interval; Forbid above keeps two


### PR DESCRIPTION
Reverts the one-line `suspend: true` added in #557.

That was the right call at the time — it stopped the beets CronJob from firing failed jobs and attach attempts every 5 minutes while the Longhorn config PVC was faulted. The condition it was waiting on has now cleared.

## What was actually wrong

Not the beets PVC specifically. Four nodes (`cp-1`, `cp-2`, `pi-5`, `pi-6`) had accumulated stale iSCSI node records under `/var/lib/iscsi/nodes/` containing `node.session.conn_reopen_log_freq`, a parameter the running `libopeniscsiusr` does not recognise. Since `iscsiadm -m node -o show` parses the **entire** node database, one unreadable record broke *every* volume attach on that node — beets, mealie and mousesearch alike.

Twenty-eight stale record directories were removed. Full writeup in `docs/postmortems/2026-08-06-longhorn-iscsi-node-db-poison.md` (#558).

## Verification

- `pvc-6efd14ad` is `attached / healthy` at its declared `numberOfReplicas: 3` (`cp-3`, `pi-5`, `pi-6`). It had been sitting at **one** replica — the cron's ~18s attach window was too short for a rebuild to finish, so it needed a deliberate held-open attach.
- A cron run completed successfully in 18s: `[import] beet import --quiet /input` → `No files imported from /input` (clean idle run).
- No `conn_reopen_log_freq` errors on any node since `06:43:41Z`.

## Note on live state

The live CronJob currently reads `suspend: false` — I patched it directly while verifying the storage fix, before realising #557 had declared it. That was drift against Git and I should not have done it. Merging this makes the declared state match what is already running, rather than leaving Flux to revert it back to suspended.