### PR TITLE
fix: stop runners dialing unreachable IPv6, and use the local registry mirrors

### DIFF
--- a/kubernetes/apps/actions-runner-system/beoftexas-runners/app/configmap.yaml
+++ b/kubernetes/apps/actions-runner-system/beoftexas-runners/app/configmap.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes-definitions.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: beoftexas-runners-dind-config
+data:
+  # The dind sidecar is a second Docker daemon that knows nothing about the
+  # pull-through mirrors Talos configures for containerd (see
+  # talos/patches/global/machine-registries.sops.yaml), so every `docker pull`
+  # in a job went straight to Docker Hub and its CloudFront blob CDN. That cost
+  # us anonymous Hub rate limits and, worse, exposed pulls to CloudFront's AAAA
+  # records -- dockerd is a CGO_ENABLED=0 Go binary whose resolver ignores
+  # AI_ADDRCONFIG, so it would dial IPv6 from an IPv4-only pod and fail with
+  # "connect: network is unreachable".
+  #
+  # Pointing at the mirror by IP literal removes DNS from the path entirely for
+  # docker.io pulls. dockerd falls back to Docker Hub on its own if the mirror
+  # is unreachable, so this is not a hard dependency.
+  #
+  # Both mirrors are listed so a single host going down does not push every pull
+  # back out to Docker Hub. dockerd tries them in order and falls back to Hub on
+  # its own if neither answers, so this is not a hard dependency.
+  #
+  # Endpoints match machine-registries.sops.yaml. Keep them in sync: that file
+  # carried a stale 192.168.10.80 for the first mirror, which no longer answers.
+  daemon.json: |
+    {
+      "registry-mirrors": [
+        "http://192.168.8.10:5000",
+        "http://192.168.10.79:5000"
+      ],
+      "insecure-registries": [
+        "192.168.8.10:5000",
+        "192.168.10.79:5000"
+      ]
+    }

--- a/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/beoftexas-runners/app/helmrelease.yaml
@@ -106,9 +106,18 @@ spec:
             volumeMounts:
               - name: work
                 mountPath: /home/runner/_work
+              # subPath so we drop daemon.json in without masking the rest of
+              # /etc/docker, which the dind image populates itself.
+              - name: dind-config
+                mountPath: /etc/docker/daemon.json
+                subPath: daemon.json
+                readOnly: true
 
         # Storage for runner work directory
         volumes:
+          - name: dind-config
+            configMap:
+              name: beoftexas-runners-dind-config
           - name: dshm
             emptyDir:
               medium: Memory

--- a/kubernetes/apps/actions-runner-system/beoftexas-runners/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/beoftexas-runners/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -55,6 +55,28 @@ spec:
             configBlock: |-
               lameduck 5s
           - name: ready
+          # This cluster is IPv4-only: clusterPodNets is 10.42.0.0/16 with
+          # single-stack Cilium, and pod netns have net.ipv6.conf.all.disable_ipv6=1
+          # with no address in /proc/net/if_inet6. No AAAA we hand out is ever
+          # reachable.
+          #
+          # glibc and musl already hide AAAA from applications via AI_ADDRCONFIG
+          # when the netns has no IPv6 address, which is why curl/git/nslookup
+          # were never affected. But Go binaries built with CGO_ENABLED=0 -- Flux,
+          # Renovate, dockerd, containerd -- use Go's own resolver, which does not
+          # implement AI_ADDRCONFIG. They query AAAA directly, get an address they
+          # cannot route to, and fail with "connect: network is unreachable".
+          # Observed as intermittent Docker Hub blob-pull failures on the runners
+          # against production.cloudfront.docker.com, which returns 9 AAAA records.
+          #
+          # NOERROR with no answer section is NODATA: "this name has no AAAA",
+          # which is the truthful answer here. No fallthrough -- the point is that
+          # nothing downstream ever produces one. Remove this block if the cluster
+          # ever gains real IPv6.
+          - name: template
+            parameters: ANY AAAA
+            configBlock: |-
+              rcode NOERROR
           - name: kubernetes
             parameters: cluster.local in-addr.arpa ip6.arpa
             configBlock: |-

--- a/talos/patches/global/machine-registries.sops.yaml
+++ b/talos/patches/global/machine-registries.sops.yaml
@@ -3,27 +3,27 @@ machine:
     mirrors:
       docker.io:
         endpoints:
-          - ENC[AES256_GCM,data:KyWsrv2wOsYU4nzTnozWRMCupOuCRmXjkw==,iv:gQkdxvSxBIEmzTT6aWB932c+FCCwMT72cwl+Aa+6R4k=,tag:y2egLRKLRNwJ1E6sZuPdRQ==,type:str]
+          - ENC[AES256_GCM,data:o9++JQOv9UfXGYIwIMiWubUOtptKEBkD,iv:YS0cg8OAB1nQ8G/uFcT176Is3W6eRMoE7z6wnJgjobc=,tag:T0pa/bTj6hrBG73bNc8g9A==,type:str]
           - ENC[AES256_GCM,data:qfP3PhLRJlN3sVpGoum72wessfnPJ/LY1A==,iv:0UAqU4cxDygfw9Y0CG7U7zDY6Fy3Qh9fmgaL2Td2A2w=,tag:aSp7oZl/mp0qJW1o/x6oYw==,type:str]
       ghcr.io:
         endpoints:
-          - ENC[AES256_GCM,data:IufaP5NKbk7wxbcv68z09miIArSWwrTw4Q==,iv:G8VijPASjfy17FxlzejalawOaazhdue3tGHWywZese4=,tag:+1vEvzzNuS7nPbLODM1keg==,type:str]
+          - ENC[AES256_GCM,data:VDe767BzQEyN2inr2Zc6/NnPqXvVMzRt,iv:AB4OlU1Aw0YK/vpT49MTdsqCub+Xj5JpduoR12YhItc=,tag:eAYhRNXXH5o1gwbf9E+Gxw==,type:str]
           - ENC[AES256_GCM,data:35FkpNCAXynTukh25yo4jMRPH1PB9c3PhA==,iv:l2SbRACNcM0yZ8GsLCvg4SX0YLbLsww8PQic6hgEMa8=,tag:EBBBbXWziI0U9pD9NeDR3g==,type:str]
       registry.k8s.io:
         endpoints:
-          - ENC[AES256_GCM,data:M2JrA372BC8pa8EH1hsFp+9udCiMuztDwg==,iv:ZyQMuRzEsK4hIUeoZ1hZ2VjMDvpCwUb93fiQP9HAMMs=,tag:zLO9nEHDVpiSeBKwaZv2ww==,type:str]
+          - ENC[AES256_GCM,data:HSMJIm6ACC3lpVwYxpo9FgeAI2Of6Avh,iv:tq5kgVNOXvfsnDUnMBtHQ/xS9PmMj8utLdTGm3XPx7o=,tag:tqa463+2JKrxFQYnk+K+tA==,type:str]
           - ENC[AES256_GCM,data:rlAfeIYELiUC++SfgnqY/6FlCOVlTekYMQ==,iv:QkLwjYbA04MZWH0iYMw9HptFZ5vQLedlD4Qg+OByn/c=,tag:Q3VaiiPiN2fUrfZkR9GwuQ==,type:str]
       gcr.io:
         endpoints:
-          - ENC[AES256_GCM,data:JTr255l9PaC5MMJAukxZlfG6+xYpUB3Tjg==,iv:tTMIxM/Ira+rLFuyaB2jrvaako+R+IZE1lWJdB1B6dE=,tag:qudt44IG6nuWomXH7PXTag==,type:str]
+          - ENC[AES256_GCM,data:HfKi/mYupXGtsH63vP+N4EXUFumqW9zs,iv:v5TI1dFZ5W7x59nIv6KjebZ2TPvUQDgdUtB8TwM2Q20=,tag:F8JcwZVZn8QQFuzbs7GmEQ==,type:str]
           - ENC[AES256_GCM,data:GOoo/fpkE1W/bKAnyxkd5piFrnKqcaDU5Q==,iv:jhoXSPHStWnD/3nvUHSufJIOCD5LxQUv8hTwcr3rw/o=,tag:6I/hTevckdVZymrapFGX2A==,type:str]
       public.ecr.aws:
         endpoints:
-          - ENC[AES256_GCM,data:uAFxi2sBlUt8QJlAhcmOwil+MeGn5mS+Fw==,iv:FCZzZbweP3aB5ZQ1bROGPKXauDx+ht5Vey2ZN72YUQg=,tag:rMDMjjxoimJTlyZ5TBvEDg==,type:str]
+          - ENC[AES256_GCM,data:dqxZIjg0Sz0KBYwf6GDTzb/9jxOGrVR3,iv:ABWZTOOZhn6fKZOl9XH637hmRDBFPuzGpOjg1uHZjnU=,tag:gZtMlo00QX26lI6RUzzCnA==,type:str]
           - ENC[AES256_GCM,data:knwioiWADBQPw1VUUa7ef/3Tm36c0dWEGA==,iv:rYEZCF+oT+giRyE+XH6wDeoasd8R+tgsKQi5fXOBpEk=,tag:KjCHJib2vW0nBkn0E5jJcg==,type:str]
       quay.io:
         endpoints:
-          - ENC[AES256_GCM,data:a5eMV3zLp/145XpGTcg4iwLbAq8jsRvyUQ==,iv:p02ciq+T/YPb0GTv/++EjVC2anLrcxa/HT+ER98X3jk=,tag:H+pFOC/CIoBFas/4aPs4Pw==,type:str]
+          - ENC[AES256_GCM,data:TzYDALyjFf6vsq79sO9PW/qfL7DEZidc,iv:psuGFKUYXh2hVJwbdYYxU7p6SI3A2dvWYd80+D8fEVI=,tag:ra4ki3UX8tvkZ4ywCAuL3Q==,type:str]
           - ENC[AES256_GCM,data:SXNZIgr1NbwUOqUBd4CAmAZ4XT0/MF9Fyw==,iv:XmU/h7hFHIlazXwEdbLkVPQq3GEpgQMN4Kgcu4Qui3s=,tag:9kZNdR6A/bfxHgfdUx080w==,type:str]
     config:
       docker.io:
@@ -32,8 +32,7 @@ machine:
           password: ENC[AES256_GCM,data:N3zFucNM3wS19HW+9ZXxbJIg1mVUy6q+Ty0+tSdIJmCxF1ui,iv:iBNeGQ/BoQhBf12rTfMbCNDQRIxjTQc0qEnhtWw7liI=,tag:4hX3J2/iVWQUzkek8vyKkw==,type:str]
 sops:
   age:
-    - recipient: age1rpavzet35zr3pgqcvz9emvgmuzlc5w9w2cjwl86arr406c6hlaqqszqt2u
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
         YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFd3hnZUM5RGpNdWxwTWc3
         ellEdDBwU2YwZUprVzFIYmNNb2dJSG13SldFCmZmM21aR3dNd3hFSUJ3ZFZUdFlF
@@ -41,8 +40,9 @@ sops:
         bUxxQmc0U3JOdkhNU1QzS1J2ZjdHMlUKbxUdDqTxY0ymYIiac3ElSebvObVguRzP
         Kf1XhNetdoBgt/5HMNhbxdTuvIccDSZ78OVSp8ij+JzOTInPm6We+w==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-02-28T17:54:12Z"
-  mac: ENC[AES256_GCM,data:5/JJVbMuGdfwelh9D6eNYh8KnabiQcW7Q3pthUb3A67IwydehGMbaPPYxqjIIZg5czs/e7gzSS8/KIV+ifgcet8xj5CRbdyS0dFM7j0hxjC+v+jFwtPl1KFzCmjfOK4DOJHlQah4aAFHn3YAo1H8az4neRWj3gHVtEN/1Qa53Ig=,iv:FGoDeu521h2u3bfvizlPyEM1gDCQXxecsHRvGJdef/k=,tag:JVPHsot9rbzXsMwW0PQw/Q==,type:str]
-  unencrypted_suffix: _unencrypted
+      recipient: age1rpavzet35zr3pgqcvz9emvgmuzlc5w9w2cjwl86arr406c6hlaqqszqt2u
+  lastmodified: "2026-08-09T02:16:15Z"
+  mac: ENC[AES256_GCM,data:kyCyRdwWBdWsk2T9SadfhyJGcYA8HmP4oqq0FkiFRottXiMVIih1e7wIY/JrlPkQmJwfn35UGxuv6UMLjAj/jKBdVG8vbbvz+5wykPuVFM0ewvu8dprmci7Pvawg1H21CFecO4+4QJujPT+cLluqCtsD0ZyCdD+v/98qYoQ2tHE=,iv:w2fXys8aVv71otiQJGd10MBW1bTnPXCx7Q8GW2yQ7qI=,tag:Z2wS78VU7IQNtSp5hGwizQ==,type:str]
   mac_only_encrypted: true
-  version: 3.12.1
+  unencrypted_suffix: _unencrypted
+  version: 3.13.3


### PR DESCRIPTION
## What broke

Docker Hub blob pulls on the `beoftexas` runners were failing intermittently:

```
docker: failed to copy: httpReadSeeker: failed open: failed to do request:
Get "https://production.cloudfront.docker.com/registry-v2/...":
dial tcp [2600:9000:202d:2a00:9:4855:aac0:93a1]:443: connect: network is unreachable
```

## Root cause

The cluster is IPv4-only — `clusterPodNets: ["10.42.0.0/16"]`, single-stack Cilium. Runner pods have `net.ipv6.conf.all.disable_ipv6=1` and nothing in `/proc/net/if_inet6`.

But CoreDNS still hands out AAAA. Raw query from inside a runner pod:

```
production.cloudfront.docker.com   A    answers = 5
production.cloudfront.docker.com   AAAA answers = 9
```

`glibc`/`musl` filter those out via `AI_ADDRCONFIG` when the netns has no IPv6 address — which is why `curl`, `git` and `nslookup` were never affected, and why this looked like a non-issue at first. `dockerd` is a **`CGO_ENABLED=0` Go binary**, and Go's resolver does not implement `AI_ADDRCONFIG`. It queries AAAA directly, gets all 14 addresses, and sometimes dials one of the 9 unroutable ones.

## Changes

**`fix(coredns)`** — `template ANY AAAA { rcode NOERROR }`, so AAAA is NODATA cluster-wide. Fixes the whole class for every Go binary in the cluster, not just dockerd. Remove it if the cluster ever gains real IPv6.

**`fix(talos)`** — `192.168.10.80` was listed first for all six registries but is fully down (100% packet loss). The live address is `192.168.8.10`, serving all six ports. containerd failed over to the second endpoint so pulls kept working, but every pull in the cluster ate a connect timeout first.

**`fix(actions-runner-system)`** — point the dind sidecar at the pull-through mirrors via `daemon.json`. Takes DNS out of the path for `docker.io` pulls entirely, and gets runners off anonymous Hub rate limits. `beoftexas` is the only pool with dind; the others have no Docker and are covered by the CoreDNS change alone.

## Verification

Rendered the CoreDNS chart (`helm template`, v1.47.0) and confirmed the Corefile, then ran **CoreDNS 1.14.6 with the real plugin set including `cache`** — `cache` sits ahead of `template` in the plugin chain and was the most likely thing to defeat this:

```
pass 1 (cold cache):   A answers=5   AAAA answers=0 rcode=0
pass 2 (warm cache):   A answers=5   AAAA answers=0 rcode=0
```

A passes through untouched, AAAA is NODATA on both paths. `kustomize build` renders clean. Mirror reachability confirmed from inside a live runner pod.

## Deploy note

The Talos commit **needs a `talos apply` to take effect** — it does not land via Flux. Worth batching with other Talos work, since an apply on this cluster also picks up the unrelated `worker-storage-exclude` topology drift. The other two commits reconcile normally.
