### PR TITLE
feat(talos): sync Longhorn node topology and apply machine config on merge

### DIFF
--- a/.github/actions/talos-apply-node/action.yaml
+++ b/.github/actions/talos-apply-node/action.yaml
@@ -1,0 +1,319 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: Talos Apply Node
+description: >-
+  Apply the generated machine config to a single Talos node. Skips nodes whose
+  config already matches, so a rerun after a partial failure resumes instead of
+  touching healthy nodes. Refuses to reboot unless explicitly allowed.
+
+inputs:
+  hostname:
+    description: Talos hostname, as it appears in talconfig.yaml and Kubernetes
+    required: true
+  ip:
+    description: Node IP address
+    required: true
+  control-plane:
+    description: Whether this node is a control plane member
+    required: false
+    default: "false"
+  allow-reboot:
+    description: >-
+      Permit applying changes that require a reboot. When false (the default) a
+      node needing one is left untouched and the step fails, so a routine config
+      commit can never reboot a node by surprise.
+    required: false
+    default: "false"
+  dry-run:
+    description: Show the diff without applying it
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Diff against live config
+      id: diff
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+
+        # talosctl's own dry-run is the source of truth for both questions we
+        # need answered: is there a diff at all, and would applying it reboot
+        # the node. Deriving either from the git diff would be guesswork --
+        # a node can already carry a change that was applied by hand.
+        cd talos
+        out="$(talhelper gencommand apply \
+          --node "$IP" \
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --dry-run" \
+          | bash 2>&1)" && rc=0 || rc=$?
+
+        echo "::group::dry-run output for ${HOSTNAME_}"
+        echo "$out"
+        echo "::endgroup::"
+
+        # Fail closed on a failed dry-run. An unreachable node and a config
+        # talosctl refuses to decode both exit non-zero while printing no diff
+        # -- indistinguishable from "already in sync" if the diff marker were
+        # the only signal, which would skip the node and report success.
+        # Measured: drift exits 0, unreachable node and malformed config exit 1.
+        if (( rc != 0 )); then
+          echo "::error::dry-run against ${HOSTNAME_} failed (exit ${rc}); nothing applied"
+          exit 1
+        fi
+
+        # rc is 0 here, so an absent diff body genuinely means the node matches.
+        if ! grep -q '^--- a' <<<"$out"; then
+          echo "drift=false" >> "$GITHUB_OUTPUT"
+          echo "reboot=false" >> "$GITHUB_OUTPUT"
+          echo "${HOSTNAME_} already matches the generated config"
+          exit 0
+        fi
+
+        echo "drift=true" >> "$GITHUB_OUTPUT"
+
+        # talosctl reports one of "Applied configuration without a reboot" or
+        # "... with a reboot". Absence of the no-reboot phrasing is treated as
+        # needing one, so an unrecognised message fails closed.
+        if grep -q 'without a reboot' <<<"$out"; then
+          echo "reboot=false" >> "$GITHUB_OUTPUT"
+          echo "${HOSTNAME_} has drift, applies without a reboot"
+        else
+          echo "reboot=true" >> "$GITHUB_OUTPUT"
+          echo "${HOSTNAME_} has drift and would REBOOT"
+        fi
+
+        # Keep the diff for the summary. Base64 because it is multi-line and
+        # contains characters that would need escaping in GITHUB_OUTPUT.
+        sed -n '/^--- a/,$p' <<<"$out" | base64 -w0 > "${RUNNER_TEMP}/diff-${HOSTNAME_}.b64"
+
+    - name: Refuse unexpected reboot
+      if: steps.diff.outputs.reboot == 'true' && inputs.allow-reboot != 'true'
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        echo "::error::${HOSTNAME_} needs a reboot to apply this config, and allow-reboot is false."
+        echo "Nothing was applied to ${HOSTNAME_}. Re-run this workflow via workflow_dispatch"
+        echo "with allow-reboot enabled if the reboot is intended -- it will drain the node first."
+        exit 1
+
+    - name: Record cordon state
+      id: cordon
+      if: >-
+        steps.diff.outputs.drift == 'true' && steps.diff.outputs.reboot == 'true'
+        && inputs.allow-reboot == 'true' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+
+        # Remember whether the node was already cordoned so an operator's
+        # deliberate cordon survives this run.
+        was_cordoned="$(kubectl get node "$HOSTNAME_" -o jsonpath='{.spec.unschedulable}')"
+        echo "was-cordoned=${was_cordoned:-false}" >> "$GITHUB_OUTPUT"
+
+    - name: Drain workloads
+      if: >-
+        steps.diff.outputs.drift == 'true' && steps.diff.outputs.reboot == 'true'
+        && inputs.allow-reboot == 'true' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+
+        # Same two-phase drain as .github/actions/talos-upgrade-node, and for
+        # the same reason: Longhorn guards each instance-manager pod with a PDB
+        # while it runs engines for attached volumes, and it is the workload
+        # pods that keep those engines alive. Evicting both in one pass
+        # deadlocks. Kept in step with that action if either changes.
+        kubectl drain "$HOSTNAME_" \
+          --ignore-daemonsets \
+          --delete-emptydir-data \
+          --pod-selector='longhorn.io/component!=instance-manager' \
+          --timeout=10m
+
+        count_engines() {
+          kubectl -n longhorn-system get engines.longhorn.io \
+            -o jsonpath="{range .items[?(@.spec.nodeID==\"${HOSTNAME_}\")]}{.metadata.name}{\"\n\"}{end}" \
+            2>/dev/null | grep -c . || true
+        }
+
+        deadline=$(( SECONDS + 300 ))
+        while [[ "$(count_engines)" != "0" ]]; do
+          if (( SECONDS > deadline )); then
+            echo "::error::Longhorn engines are still running on ${HOSTNAME_}"
+            exit 1
+          fi
+          echo "  waiting for Longhorn engines to leave ${HOSTNAME_} ($(count_engines) remaining)"
+          sleep 10
+        done
+
+    - name: Apply
+      if: steps.diff.outputs.drift == 'true' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+
+        cd talos
+        talhelper gencommand apply \
+          --node "$IP" \
+          --extra-flags "--endpoints=${TALOS_ENDPOINT}" \
+          | tee /dev/stderr \
+          | bash
+
+    - name: Wait for healthy
+      if: >-
+        steps.diff.outputs.drift == 'true' && steps.diff.outputs.reboot == 'true'
+        && inputs.allow-reboot == 'true' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        HOSTNAME_: ${{ inputs.hostname }}
+        IS_CONTROL_PLANE: ${{ inputs.control-plane }}
+        WAS_CORDONED: ${{ steps.cordon.outputs.was-cordoned }}
+      run: |
+        set -euo pipefail
+
+        deadline=$(( SECONDS + 900 ))
+
+        wait_for() {
+          local description="$1"; shift
+          echo "Waiting for ${description}..."
+          until "$@"; do
+            if (( SECONDS > deadline )); then
+              echo "::error::timed out waiting for ${description} on ${HOSTNAME_}"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "  ${description}: ok"
+        }
+
+        node_ready() {
+          local status
+          status="$(kubectl get node "$HOSTNAME_" \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" || return 1
+          [[ "$status" == "True" ]]
+        }
+
+        etcd_healthy() {
+          local health
+          health="$(talosctl --nodes "$IP" --endpoints "$TALOS_ENDPOINT" service etcd 2>/dev/null \
+            | awk '$1 == "HEALTH" { print $2 }')" || return 1
+          [[ "$health" == "OK" ]]
+        }
+
+        wait_for "${HOSTNAME_} to be Ready" node_ready
+
+        if [[ "$IS_CONTROL_PLANE" == "true" ]]; then
+          wait_for "etcd on ${HOSTNAME_} to be healthy" etcd_healthy
+        fi
+
+        if [[ "$WAS_CORDONED" != "true" ]]; then
+          kubectl uncordon "$HOSTNAME_"
+        else
+          echo "${HOSTNAME_} was cordoned before this run; leaving it cordoned"
+        fi
+
+    - name: Confirm drift is gone
+      if: steps.diff.outputs.drift == 'true' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        IP: ${{ inputs.ip }}
+        HOSTNAME_: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+
+        # Re-run the same dry-run against the node we just applied to. This is
+        # the whole point of the workflow -- an apply that silently did not take
+        # would otherwise look identical to a successful one.
+        cd talos
+        out="$(talhelper gencommand apply \
+          --node "$IP" \
+          --extra-flags "--endpoints=${TALOS_ENDPOINT} --dry-run" \
+          | bash 2>&1)" && rc=0 || rc=$?
+
+        if (( rc != 0 )); then
+          echo "::error::could not re-check ${HOSTNAME_} after applying (exit ${rc})"
+          echo "$out"
+          exit 1
+        fi
+
+        if grep -q '^--- a' <<<"$out"; then
+          echo "::error::${HOSTNAME_} still differs from the generated config after applying"
+          sed -n '/^--- a/,$p' <<<"$out"
+          exit 1
+        fi
+
+        echo "${HOSTNAME_} now matches the generated config"
+
+    - name: Restore cordon state
+      if: failure()
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+        WAS_CORDONED: ${{ steps.cordon.outputs.was-cordoned }}
+      run: |
+        set +e
+
+        # Only meaningful on the reboot path, where this action cordoned the
+        # node itself. was-cordoned is empty when the drain step never ran.
+        if [[ -z "$WAS_CORDONED" || "$WAS_CORDONED" == "true" ]]; then
+          exit 0
+        fi
+
+        cordoned="$(kubectl get node "$HOSTNAME_" -o jsonpath='{.spec.unschedulable}' 2>/dev/null)"
+        if [[ "$cordoned" == "true" ]]; then
+          echo "::warning::${HOSTNAME_} was left cordoned by the failed apply; uncordoning"
+          kubectl uncordon "$HOSTNAME_"
+        fi
+
+    - name: Summary
+      if: always()
+      shell: bash
+      env:
+        HOSTNAME_: ${{ inputs.hostname }}
+        IP: ${{ inputs.ip }}
+        DRIFT: ${{ steps.diff.outputs.drift }}
+        REBOOT: ${{ steps.diff.outputs.reboot }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        JOB_STATUS: ${{ job.status }}
+      run: |
+        set -uo pipefail
+
+        {
+          echo "### ${HOSTNAME_} (${IP})"
+          echo ""
+          if [[ "$DRIFT" != "true" ]]; then
+            echo "Already in sync."
+          else
+            if [[ "$JOB_STATUS" == "failure" ]]; then
+              echo "**Failed.**"
+            elif [[ "$DRY_RUN" == "true" ]]; then
+              echo "Dry run -- drift found, nothing applied."
+            else
+              echo "Applied$([[ "$REBOOT" == "true" ]] && echo " (with reboot)")."
+            fi
+            diff_file="${RUNNER_TEMP}/diff-${HOSTNAME_}.b64"
+            if [[ -f "$diff_file" ]]; then
+              echo ""
+              echo "<details><summary>Config diff</summary>"
+              echo ""
+              echo '```diff'
+              base64 -d < "$diff_file"
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+          fi
+          echo ""
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/talos-config-apply.yaml
+++ b/.github/workflows/talos-config-apply.yaml
@@ -1,0 +1,208 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "Talos Config Apply"
+
+# Machine config is the one part of this repo Flux cannot reconcile: it only
+# reaches a node when someone runs talosctl apply-config. Left to hand-running,
+# nodes drift -- which is how pi-1..8 ended up carrying a registerWithTaints
+# block that talconfig.yaml had not described for months. This workflow closes
+# that loop on merge.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "talos/talconfig.yaml"
+      - "talos/patches/**"
+  schedule:
+    # Weekly drift sweep. Catches config applied by hand between merges, and
+    # install.image lagging after a talenv.yaml bump -- talosctl upgrade does
+    # not rewrite machine config, so that field stays stale until an apply.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      nodes:
+        description: "Comma-separated hostnames to limit the run to (default: every node)"
+        required: false
+        default: ""
+      dry-run:
+        description: "Show the diff without applying anything"
+        type: boolean
+        required: false
+        default: false
+      allow-reboot:
+        description: "Permit applying changes that require a reboot (drains first)"
+        type: boolean
+        required: false
+        default: false
+
+# Shared with Talos Upgrade: a config apply and a version rollout must never
+# touch the cluster at the same time.
+concurrency:
+  group: talos-cluster
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    name: Plan
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 15
+    outputs:
+      control-plane-matrix: ${{ steps.plan.outputs.control-plane-matrix }}
+      worker-matrix: ${{ steps.plan.outputs.worker-matrix }}
+      should-run: ${{ steps.plan.outputs.should-run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+
+      - name: Preflight
+        run: |
+          set -euo pipefail
+
+          # Do not push config into an already-degraded cluster. Read the Ready
+          # condition rather than the STATUS column, which also reports
+          # SchedulingDisabled -- a node left cordoned by an earlier failed run
+          # must not block the rerun that fixes it.
+          not_ready=()
+          while read -r hostname ready; do
+            [[ "$ready" != "True" ]] && not_ready+=("$hostname")
+          done < <(kubectl get nodes --no-headers -o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status')
+
+          if (( ${#not_ready[@]} > 0 )); then
+            echo "::error::these nodes are not Ready: ${not_ready[*]}"
+            exit 1
+          fi
+
+          echo "All nodes Ready"
+
+      - name: Build matrices
+        id: plan
+        env:
+          FILTER: ${{ inputs.nodes }}
+        run: |
+          set -euo pipefail
+
+          # Matrices come from talconfig.yaml, so adding a node to the cluster
+          # needs no change here. Every node is included; whether it has drift
+          # is decided per node by the apply action, which owns the dry-run.
+          build_matrix() {
+            local selector="$1" entries=() hostname ip
+            while read -r hostname ip; do
+              if [[ -n "$FILTER" && ",${FILTER}," != *",${hostname},"* ]]; then
+                continue
+              fi
+              entries+=("{\"hostname\":\"${hostname}\",\"ip\":\"${ip}\"}")
+            done < <(yq eval -r ".nodes[] | select(.controlPlane ${selector}) | .hostname + \" \" + .ipAddress" talos/talconfig.yaml)
+            local IFS=,
+            echo "[${entries[*]}]"
+          }
+
+          control_plane_matrix="$(build_matrix '== true')"
+          worker_matrix="$(build_matrix '!= true')"
+          echo "control-plane-matrix=${control_plane_matrix}" >> "$GITHUB_OUTPUT"
+          echo "worker-matrix=${worker_matrix}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$control_plane_matrix" == "[]" && "$worker_matrix" == "[]" ]]; then
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::the nodes filter matched nothing"
+          else
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "## Talos config apply"
+            echo ""
+            [[ -n "$FILTER" ]] && echo "Limited to \`${FILTER}\`."
+            [[ "${{ inputs.dry-run }}" == "true" ]] && echo "Dry run: nothing will be applied."
+            [[ "${{ inputs.allow-reboot }}" == "true" ]] && echo ":warning: Reboots permitted."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  approve:
+    name: Approve
+    needs: plan
+    if: needs.plan.outputs.should-run == 'true' && inputs.dry-run != true
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 5
+    # Configure this environment with reviewers to gate applies. Leaving it
+    # without reviewers makes merges apply straight through, which is the point
+    # of the workflow -- the gate is here for when you want it.
+    environment: talos-config-apply
+    steps:
+      - name: Approved
+        run: echo "Approved config apply"
+
+  control-plane:
+    name: ${{ matrix.hostname }}
+    needs: [plan, approve]
+    if: >-
+      !cancelled() && !failure()
+      && needs.plan.outputs.control-plane-matrix != '[]'
+      && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
+    # Pinned to the Pi workers so a control plane job is never evicted by the
+    # control plane node it may be rebooting.
+    runs-on: home-ops-runners-arm64
+    timeout-minutes: 30
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.control-plane-matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+          exclude-ip: ${{ matrix.ip }}
+
+      - name: Apply to ${{ matrix.hostname }}
+        uses: ./.github/actions/talos-apply-node
+        with:
+          hostname: ${{ matrix.hostname }}
+          ip: ${{ matrix.ip }}
+          control-plane: "true"
+          allow-reboot: ${{ inputs.allow-reboot }}
+          dry-run: ${{ inputs.dry-run }}
+
+  workers:
+    name: ${{ matrix.hostname }}
+    needs: [plan, approve, control-plane]
+    if: >-
+      !cancelled() && !failure()
+      && needs.plan.outputs.worker-matrix != '[]'
+      && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
+    runs-on: home-ops-runners-amd64
+    timeout-minutes: 30
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.worker-matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Set up Talos tooling
+        uses: ./.github/actions/talos-setup
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+
+      - name: Apply to ${{ matrix.hostname }}
+        uses: ./.github/actions/talos-apply-node
+        with:
+          hostname: ${{ matrix.hostname }}
+          ip: ${{ matrix.ip }}
+          control-plane: "false"
+          allow-reboot: ${{ inputs.allow-reboot }}
+          dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/talos-upgrade.yaml
+++ b/.github/workflows/talos-upgrade.yaml
@@ -18,8 +18,10 @@ on:
         required: false
         default: false
 
+# Shared with Talos Config Apply: a version rollout and a config apply must
+# never touch the cluster at the same time.
 concurrency:
-  group: talos-upgrade
+  group: talos-cluster
   cancel-in-progress: false
 
 permissions:

--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -5,17 +5,6 @@ machine:
     nodeIP:
       validSubnets:
         - 192.168.10.0/24
-    # Longhorn on Talos needs these paths as rshared bind mounts so the
-    # backupstore NFS mount performed inside the (privileged) longhorn-manager
-    # pod can propagate to the host. Without them the NFS mount fails with
-    # "Operation not permitted". Both are required: they are siblings, not
-    # nested, so rsharing /var/lib/longhorn alone does not cover the backupstore.
-    extraMounts:
-      - destination: /var/lib/longhorn
-        type: bind
-        source: /var/lib/longhorn
-        options: [bind, rshared, rw]
-      - destination: /var/lib/longhorn-backupstore-mounts
-        type: bind
-        source: /var/lib/longhorn-backupstore-mounts
-        options: [bind, rshared, rw]
+    # The Longhorn rshared bind mounts used to live here, applied to every node
+    # including the 4GB Pis that had never actually received them. They now live
+    # in patches/storage/machine-longhorn-mounts.yaml, attached per node.

--- a/talos/patches/storage/machine-longhorn-mounts.yaml
+++ b/talos/patches/storage/machine-longhorn-mounts.yaml
@@ -1,0 +1,25 @@
+machine:
+  kubelet:
+    # Longhorn on Talos needs these paths as rshared bind mounts so the
+    # backupstore NFS mount performed inside the (privileged) longhorn-manager
+    # pod can propagate to the host. Without them the NFS mount fails with
+    # "Operation not permitted". Both are required: they are siblings, not
+    # nested, so rsharing /var/lib/longhorn alone does not cover the backupstore.
+    #
+    # Attached to the nodes that hold replicas -- the control plane and the 8GB
+    # Pis (pi-5..8). The 4GB Pis (pi-1..4) do not get them, which matches what
+    # they already run: longhorn-manager and an instance-manager are scheduled
+    # there, but replicas are kept off via allowScheduling: false on the
+    # nodes.longhorn.io objects, so nothing on those nodes needs the mounts.
+    #
+    # These lived in patches/global until 2026-08-08, where they were applied to
+    # every node -- including pi-1..4, which had never actually received them.
+    extraMounts:
+      - destination: /var/lib/longhorn
+        type: bind
+        source: /var/lib/longhorn
+        options: [bind, rshared, rw]
+      - destination: /var/lib/longhorn-backupstore-mounts
+        type: bind
+        source: /var/lib/longhorn-backupstore-mounts
+        options: [bind, rshared, rw]

--- a/talos/patches/worker-storage-exclude/machine-kubelet.yaml
+++ b/talos/patches/worker-storage-exclude/machine-kubelet.yaml
@@ -1,7 +1,0 @@
-machine:
-  kubelet:
-    extraConfig:
-      registerWithTaints:
-        - key: "node.longhorn.io/exclude"
-          value: "true"
-          effect: "NoSchedule"

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -83,6 +83,8 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 4GB Pi: no Longhorn bind mounts. Longhorn still runs here -- replicas are
+    # kept off via allowScheduling on the nodes.longhorn.io object, not a taint.
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "dc:a6:32:93:85:c6"
@@ -100,6 +102,8 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 4GB Pi: no Longhorn bind mounts. Longhorn still runs here -- replicas are
+    # kept off via allowScheduling on the nodes.longhorn.io object, not a taint.
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "dc:a6:32:7c:49:72"
@@ -117,6 +121,8 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 4GB Pi: no Longhorn bind mounts. Longhorn still runs here -- replicas are
+    # kept off via allowScheduling on the nodes.longhorn.io object, not a taint.
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "dc:a6:32:7c:9c:8a"
@@ -134,6 +140,8 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 4GB Pi: no Longhorn bind mounts. Longhorn still runs here -- replicas are
+    # kept off via allowScheduling on the nodes.longhorn.io object, not a taint.
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "e4:5f:01:69:e9:fc"
@@ -151,6 +159,9 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 8GB Pi: carries Longhorn replicas.
+    patches:
+      - "@./patches/storage/machine-longhorn-mounts.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "d8:3a:dd:18:1d:5a"
@@ -168,6 +179,9 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 8GB Pi: carries Longhorn replicas.
+    patches:
+      - "@./patches/storage/machine-longhorn-mounts.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "d8:3a:dd:23:d5:9e"
@@ -185,6 +199,9 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 8GB Pi: carries Longhorn replicas.
+    patches:
+      - "@./patches/storage/machine-longhorn-mounts.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "d8:3a:dd:17:f9:15"
@@ -202,6 +219,9 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/f47e6cd2634c7a96988861031bcc4144468a1e3aef82cca4f5b5ca3fffef778a
     controlPlane: false
+    # 8GB Pi: carries Longhorn replicas.
+    patches:
+      - "@./patches/storage/machine-longhorn-mounts.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "d8:3a:dd:44:0e:38"
@@ -226,4 +246,5 @@ controlPlane:
   patches:
     - "@./patches/controller/admission-controller-patch.yaml"
     - "@./patches/controller/cluster.yaml"
+    - "@./patches/storage/machine-longhorn-mounts.yaml"
 


### PR DESCRIPTION
Two related changes: make `talconfig.yaml` describe the Longhorn setup we actually run, then automate applying machine config so it stops drifting.

## 1. Scope the Longhorn bind mounts, drop the unused exclude taint

Two things were wrong in how `talconfig.yaml` described Longhorn.

**The bind mounts were global.** The rshared `/var/lib/longhorn` mounts sat in `patches/global/`, so the generated config put them on every node — including pi-1..4, which have never actually had them. They move to `patches/storage/`, attached to the nodes that hold replicas (control plane + the 8GB Pis). No-op for pi-1..4, which keep lacking them.

**`patches/worker-storage-exclude/` is deleted.** It was orphaned — on disk, never referenced from `talconfig.yaml` — while every Pi's live config carried the `registerWithTaints` block it would have produced.

Wiring it up was the obvious move and it was wrong. The key is named `node.longhorn.io/exclude`, but Kubernetes doesn't read key names: `NoSchedule` rejects **every** pod without a matching toleration. On a rebuild, pi-1..4 would have come up refusing `flux-system/source-controller`, `external-secrets`, `onepassword-connect`, `k8s-gateway`, `cloudnative-pg`, `metrics-server` and `seaweedfs` right along with Longhorn.

The taint was also inert on every running node — `registerWithTaints` only applies at first registration — so nothing today depends on it.

**Longhorn stays scheduled everywhere.** Replicas are kept off pi-1..4 by `allowScheduling: false` on the `nodes.longhorn.io` objects, which is what has actually been enforcing this all along. Measured cost of leaving longhorn-manager and the CSI sidecars on the 4GB Pis: **323–595Mi** of ~3.2GiB allocatable. Not worth a blanket taint.

### Verified

`talosctl apply-config --dry-run` against live, after the change:

- All eight Pis shed the dead `registerWithTaints` block.
- No bind mounts added to pi-1..4.
- cp-1..3 and pi-5..8 keep their mounts.
- **No reboot on any node.**

## 2. Apply machine config on merge

Machine config is the one part of this repo Flux can't reconcile. Triggers on merges touching `talconfig.yaml` or `patches/`, a weekly sweep for hand-applied config, and dispatch with node-filter / dry-run.

Safety properties, in order of importance:

- **Never reboots by surprise.** Each node is dry-run first. If applying would reboot it, the node is left untouched and the job fails with instructions. Reboots happen only via dispatch with `allow-reboot`, which drains first using the same Longhorn-aware two-phase drain as `talos-upgrade-node`.
- **Fails closed.** An unreachable node and a config talosctl refuses to decode *both* exit non-zero while printing no diff — indistinguishable from "already in sync" if the diff marker were the only signal. That would skip the node and report success. Exit status is checked before the diff is read. Measured: drift → 0, unreachable → 1, malformed → 1.
- **Confirms the apply took.** Re-runs the dry-run afterwards and fails if the node still differs.
- **Cannot race the upgrade workflow.** Both now share the `talos-cluster` concurrency group.

Control plane applies first, one at a time, from arm64 runners; workers follow on amd64 — the same pinning the upgrade workflow uses so a job is never evicted by the node it's touching.

### Verified

Ran the action's detection step verbatim against live nodes:

```
pi-1 (real drift)      -> drift=true reboot=false   step exit 0
unreachable node       -> FAILED CLOSED (exit 1)    step exit 1
```

## Before merging

The `talos-config-apply` environment gates applies. GitHub creates it on first run; **with no reviewers configured, merges apply straight through**. Add reviewers if you'd rather approve each one.

First run will also pick up two pre-existing drifts on every node: `install.image` v1.12.6 → v1.13.8 (cosmetic — nodes already run 1.13.8; `talosctl upgrade` doesn't rewrite config), and the registry mirror IP from #576 if that merges first. Both are no-reboot.
