### PR TITLE
feat(coredns): add the secondary Pi-hole to the kalde.in forwarders

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -29,7 +29,12 @@ spec:
       clusterIP: "10.43.0.10"
     replicaCount: 2
     servers:
-      # Forward kalde.in queries to Pi-hole for split-horizon DNS
+      # Forward kalde.in queries to Pi-hole for split-horizon DNS.
+      # Both Pi-holes are listed -- cerritos (primary) and saopaulo (secondary),
+      # matching what Kea hands out -- so losing one host does not take internal
+      # name resolution down with it. They serve identical records: the primary
+      # owns them and rsyncs to the secondary every 30min (calypso-deploy's
+      # setup-pihole-secondary.yaml).
       - zones:
           - zone: kalde.in
             scheme: dns://
@@ -39,7 +44,7 @@ spec:
           - name: cache
             parameters: 30
           - name: forward
-            parameters: . 192.168.8.10
+            parameters: . 192.168.8.10 192.168.8.11
           - name: log
             configBlock: |-
               class error


### PR DESCRIPTION
The `kalde.in` zone forwards to `192.168.8.10` only, so cerritos going down takes
internal name resolution down with it. This adds saopaulo (`192.168.8.11`) as a
second forwarder, matching the pair Kea hands out.

Both Pi-holes serve identical records — the primary owns them and rsyncs to the
secondary every 30 min via calypso-deploy's `setup-pihole-secondary.yaml` — so
there's no split-brain risk in listing both.

```diff
-            parameters: . 192.168.8.10
+            parameters: . 192.168.8.10 192.168.8.11
```

Verified the live cluster currently matches git (`forward . 192.168.8.10`), and
CoreDNS here is Flux-managed (`kubernetes/apps/kube-system/coredns/` with its own
`ks.yaml`), so merging reconciles on its own.

## This is an addition, not part of the .10.79 decommission

Nothing in this repo's DNS config ever referenced `192.168.10.79`. I swept
`kubernetes/`, `talos/` and `bootstrap/`, including decrypting the SOPS files.

**The `.10.79` endpoints in this repo are container registry mirrors, not DNS** —
`beoftexas-runners/app/configmap.yaml` and `talos/patches/global/machine-registries.sops.yaml`
both list `192.168.10.79:5000-5005` next to `192.168.8.10:5000-5005`. excelsior
keeps serving those; only its Pi-hole role was retired in
khaoslabs/calypso-deploy#143. **Leave them alone** — a future grep for `.10.79`
will surface them and they look like leftovers, but they aren't.

Talos `machine.network.nameservers` is `1.1.1.1` / `1.0.0.1` and is deliberately
not part of this: the `.` zone forwards to `/etc/resolv.conf`, so public DNS goes
to Cloudflare and only `kalde.in` goes to the Pi-holes.